### PR TITLE
Update naming to Trino

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@
 # 7) `make snapshot' as needed to push snapshot images to dockerhub
 #
 VERSION := 39-SNAPSHOT
+CACHE_FROM_VERSION := 38
 RELEASE_TYPE := $(if $(filter %-SNAPSHOT, $(VERSION)),snapshot,release)
 
 LABEL := io.trino.git.hash=$(shell git rev-parse HEAD)
@@ -184,7 +185,7 @@ $(LATEST_TAGS): %@latest: %/Dockerfile %-parent-check
 	@echo
 	@echo "Building [$@] image"
 	@echo
-	cd $* && time $(SHELL) -c "( tar -czh . | docker build ${BUILD_ARGS} $(DBFLAGS_$*) -t $(call docker-tag,$@) --label $(LABEL) - )"
+	cd $* && time $(SHELL) -c "( tar -czh . | docker build --cache-from=$(subst @latest,:${CACHE_FROM_VERSION},$(call resolved-image-name,$@)) ${BUILD_ARGS} $(DBFLAGS_$*) -t $(call docker-tag,$@) --label $(LABEL) - )"
 	docker history $(call docker-tag,$@)
 
 $(VERSION_TAGS): %@$(VERSION): %@latest

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@
 # 7) `make snapshot' as needed to push snapshot images to dockerhub
 #
 VERSION := 39-SNAPSHOT
-CACHE_FROM_VERSION := 38
 RELEASE_TYPE := $(if $(filter %-SNAPSHOT, $(VERSION)),snapshot,release)
 
 LABEL := io.trino.git.hash=$(shell git rev-parse HEAD)
@@ -185,7 +184,7 @@ $(LATEST_TAGS): %@latest: %/Dockerfile %-parent-check
 	@echo
 	@echo "Building [$@] image"
 	@echo
-	cd $* && time $(SHELL) -c "( tar -czh . | docker build --cache-from=$(subst @latest,:${CACHE_FROM_VERSION},$(call resolved-image-name,$@)) ${BUILD_ARGS} $(DBFLAGS_$*) -t $(call docker-tag,$@) --label $(LABEL) - )"
+	cd $* && time $(SHELL) -c "( tar -czh . | docker build ${BUILD_ARGS} $(DBFLAGS_$*) -t $(call docker-tag,$@) --label $(LABEL) - )"
 	docker history $(call docker-tag,$@)
 
 $(VERSION_TAGS): %@$(VERSION): %@latest

--- a/bin/depend.sh
+++ b/bin/depend.sh
@@ -5,26 +5,30 @@ usage() {
 }
 
 find_parent() {
-	awk '
+	awk "
 		BEGIN {
 			ec = 1;
 		}
 
-		$1 == "FROM" && parent {
+		\$1 == \"FROM\" && parent {
 			ec = 2;
 			exit;
 		}
 
-		$1 == "FROM" {
-			split($0, a);
-			parent = $2;
+		\$1 == \"FROM\" {
+			split(\$0, a);
+			parent = \$2;
 			ec = 0
-			print parent;
+
+			if (length(parent) == 12 && parent ~ /[[:alpha:]]/)
+        print \"${target_cache_image}\";
+      else
+			  print parent;
 		}
 
 		END {
 			exit ec
-		}' "$1"
+		}" "$2"
 }
 
 contains() {
@@ -141,10 +145,12 @@ fi
 
 target_dockerfile=$1
 target_image=$(dirname "$target_dockerfile")
+target_cache_image="ghcr.io/trinodb/${target_image}:38"
+
 shift
 known_images="$*"
 
-parent_image_tag=$(find_parent "$target_dockerfile")
+parent_image_tag=$(find_parent "$target_cache_image" "$target_dockerfile")
 ec=$?
 case $ec in
 	0) ;;

--- a/bin/depend.sh
+++ b/bin/depend.sh
@@ -5,30 +5,26 @@ usage() {
 }
 
 find_parent() {
-	awk "
+	awk '
 		BEGIN {
 			ec = 1;
 		}
 
-		\$1 == \"FROM\" && parent {
+		$1 == "FROM" && parent {
 			ec = 2;
 			exit;
 		}
 
-		\$1 == \"FROM\" {
-			split(\$0, a);
-			parent = \$2;
+		$1 == "FROM" {
+			split($0, a);
+			parent = $2;
 			ec = 0
-
-			if (length(parent) == 12 && parent ~ /[[:alpha:]]/)
-        print \"${target_cache_image}\";
-      else
-			  print parent;
+			print parent;
 		}
 
 		END {
 			exit ec
-		}" "$2"
+		}' "$1"
 }
 
 contains() {
@@ -145,12 +141,10 @@ fi
 
 target_dockerfile=$1
 target_image=$(dirname "$target_dockerfile")
-target_cache_image="ghcr.io/trinodb/${target_image}:38"
-
 shift
 known_images="$*"
 
-parent_image_tag=$(find_parent "$target_cache_image" "$target_dockerfile")
+parent_image_tag=$(find_parent "$target_dockerfile")
 ec=$?
 case $ec in
 	0) ;;

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -25,35 +25,35 @@ function environment_compose() {
 }
 
 function check_hadoop() {
-  environment_compose exec hadoop-master hive -e 'select 1;' > /dev/null 2>&1
+  environment_compose exec hadoop hive -e 'select 1;' > /dev/null 2>&1
 }
 
 function run_hadoop_tests() {
-  environment_compose exec hadoop-master hive -e 'SELECT 1' &&
-  environment_compose exec hadoop-master hive -e 'CREATE TABLE foo (a INT);' &&
-  environment_compose exec hadoop-master hive -e 'INSERT INTO foo VALUES (54);' &&
+  environment_compose exec hadoop hive -e 'SELECT 1' &&
+  environment_compose exec hadoop hive -e 'CREATE TABLE foo (a INT);' &&
+  environment_compose exec hadoop hive -e 'INSERT INTO foo VALUES (54);' &&
   # SELECT with WHERE to make sure that map-reduce job is scheduled
-  environment_compose exec hadoop-master hive -e 'SELECT a FROM foo WHERE a > 0;' &&
+  environment_compose exec hadoop hive -e 'SELECT a FROM foo WHERE a > 0;' &&
   # Test table bucketing
-  environment_compose exec hadoop-master hive -e '
+  environment_compose exec hadoop hive -e '
     CREATE TABLE bucketed_table(a INT) CLUSTERED BY(a) INTO 32 BUCKETS;
     SET hive.enforce.bucketing = true;
     INSERT INTO bucketed_table VALUES (1), (2), (3), (4);
   ' &&
-  test $(environment_compose exec hadoop-master hdfs dfs -ls /user/hive/warehouse/bucketed_table \
+  test $(environment_compose exec hadoop hdfs dfs -ls /user/hive/warehouse/bucketed_table \
     | tee /dev/stderr | grep /bucketed_table/ | wc -l) -ge 4 &&
   true
 }
 
 function run_hive_transactional_tests() {
-    environment_compose exec hadoop-master hive -e "
+    environment_compose exec hadoop hive -e "
       CREATE TABLE transactional_table (x int) STORED AS orc TBLPROPERTIES ('transactional'='true');
       INSERT INTO transactional_table VALUES (1), (2), (3), (4);
     " &&
-    environment_compose exec hadoop-master hive -e 'SELECT x FROM transactional_table WHERE x > 0;' &&
-    environment_compose exec hadoop-master hive -e 'DELETE FROM transactional_table WHERE x = 2;' &&
-    environment_compose exec hadoop-master hive -e 'UPDATE transactional_table SET x = 14 WHERE x = 4;' &&
-    environment_compose exec hadoop-master hive -e 'SELECT x FROM transactional_table WHERE x > 0;' &&
+    environment_compose exec hadoop hive -e 'SELECT x FROM transactional_table WHERE x > 0;' &&
+    environment_compose exec hadoop hive -e 'DELETE FROM transactional_table WHERE x = 2;' &&
+    environment_compose exec hadoop hive -e 'UPDATE transactional_table SET x = 14 WHERE x = 4;' &&
+    environment_compose exec hadoop hive -e 'SELECT x FROM transactional_table WHERE x > 0;' &&
     true
 }
 

--- a/etc/compose/cdh5.12-hive/docker-compose.yml
+++ b/etc/compose/cdh5.12-hive/docker-compose.yml
@@ -1,5 +1,5 @@
 version: '2.0'
 services:
-  hadoop-master:
-    hostname: hadoop-master
+  hadoop:
+    hostname: hadoop
     image: testing/cdh5.12-hive:latest

--- a/etc/compose/cdh5.15-hive/docker-compose.yml
+++ b/etc/compose/cdh5.15-hive/docker-compose.yml
@@ -1,5 +1,5 @@
 version: '2.0'
 services:
-  hadoop-master:
-    hostname: hadoop-master
+  hadoop:
+    hostname: hadoop
     image: testing/cdh5.15-hive:latest

--- a/etc/compose/hdp2.6-hive/docker-compose.yml
+++ b/etc/compose/hdp2.6-hive/docker-compose.yml
@@ -1,5 +1,5 @@
 version: '2.0'
 services:
-  hadoop-master:
-    hostname: hadoop-master
+  hadoop:
+    hostname: hadoop
     image: testing/hdp2.6-hive:latest

--- a/etc/compose/hdp3.1-hive/docker-compose.yml
+++ b/etc/compose/hdp3.1-hive/docker-compose.yml
@@ -1,5 +1,5 @@
 version: '2.0'
 services:
-  hadoop-master:
-    hostname: hadoop-master
+  hadoop:
+    hostname: hadoop
     image: testing/hdp3.1-hive:latest

--- a/etc/compose/hive3.1-hive/docker-compose.yml
+++ b/etc/compose/hive3.1-hive/docker-compose.yml
@@ -1,5 +1,5 @@
 version: '2.0'
 services:
-  hadoop-master:
-    hostname: hadoop-master
+  hadoop:
+    hostname: hadoop
     image: testing/hive3.1-hive:latest

--- a/testing/cdh5.12-hive-kerberized/Dockerfile
+++ b/testing/cdh5.12-hive-kerberized/Dockerfile
@@ -25,16 +25,16 @@ RUN /usr/local/bin/apply-all-site-xml-overrides /overrides
 RUN /usr/sbin/kdb5_util create -s -P password
 
 # ADD HADOOP PRINCIPALS
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey hdfs/hadoop-master@LABS.TRINO.IO" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey mapred/hadoop-master@LABS.TRINO.IO" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey yarn/hadoop-master@LABS.TRINO.IO" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/hadoop-master@LABS.TRINO.IO" 
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hdfs/hadoop@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey mapred/hadoop@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey yarn/hadoop@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/hadoop@LABS.TRINO.IO" 
 
 # CREATE HADOOP KEYTAB FILES
-RUN /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/hdfs.keytab hdfs/hadoop-master HTTP/hadoop-master" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/mapred.keytab mapred/hadoop-master HTTP/hadoop-master" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/yarn.keytab yarn/hadoop-master HTTP/hadoop-master" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/HTTP.keytab HTTP/hadoop-master"
+RUN /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/hdfs.keytab hdfs/hadoop HTTP/hadoop" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/mapred.keytab mapred/hadoop HTTP/hadoop" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/yarn.keytab yarn/hadoop HTTP/hadoop" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/HTTP.keytab HTTP/hadoop"
 RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs.keytab \
   && chown mapred:hadoop /etc/hadoop/conf/mapred.keytab \
   && chown yarn:hadoop /etc/hadoop/conf/yarn.keytab \
@@ -42,8 +42,8 @@ RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs.keytab \
   && chmod 644 /etc/hadoop/conf/*.keytab
 
 # CREATE HIVE PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop-master@LABS.TRINO.IO" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hive/conf/hive.keytab hive/hadoop-master"
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hive/conf/hive.keytab hive/hadoop"
 RUN chown hive:hadoop /etc/hive/conf/hive.keytab \
   && chmod 644 /etc/hive/conf/hive.keytab
 

--- a/testing/cdh5.12-hive-kerberized/Dockerfile
+++ b/testing/cdh5.12-hive-kerberized/Dockerfile
@@ -25,10 +25,10 @@ RUN /usr/local/bin/apply-all-site-xml-overrides /overrides
 RUN /usr/sbin/kdb5_util create -s -P password
 
 # ADD HADOOP PRINCIPALS
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey hdfs/hadoop-master@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey mapred/hadoop-master@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey yarn/hadoop-master@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/hadoop-master@LABS.TERADATA.COM" 
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hdfs/hadoop-master@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey mapred/hadoop-master@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey yarn/hadoop-master@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/hadoop-master@LABS.TRINO.IO" 
 
 # CREATE HADOOP KEYTAB FILES
 RUN /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/hdfs.keytab hdfs/hadoop-master HTTP/hadoop-master" \
@@ -42,7 +42,7 @@ RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs.keytab \
   && chmod 644 /etc/hadoop/conf/*.keytab
 
 # CREATE HIVE PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop-master@LABS.TERADATA.COM" \
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop-master@LABS.TRINO.IO" \
   && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hive/conf/hive.keytab hive/hadoop-master"
 RUN chown hive:hadoop /etc/hive/conf/hive.keytab \
   && chmod 644 /etc/hive/conf/hive.keytab
@@ -51,13 +51,13 @@ RUN chown hive:hadoop /etc/hive/conf/hive.keytab \
 RUN chmod 6050 /etc/hadoop/conf/container-executor.cfg
 
 # CREATE TRINO PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-1.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-2.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-coordinator.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-1.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-2.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-coordinator.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-coordinator.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-coordinator.docker.cluster@LABS.TRINO.IO" \
   && mkdir -p /etc/trino/conf \
   && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server.keytab trino-server/trino-coordinator.docker.cluster trino-server/trino-worker.docker.cluster trino-server/trino-worker-1.docker.cluster trino-server/trino-worker-2.docker.cluster" \
   && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server-HTTP.keytab HTTP/trino-coordinator.docker.cluster" \

--- a/testing/cdh5.12-hive-kerberized/Dockerfile
+++ b/testing/cdh5.12-hive-kerberized/Dockerfile
@@ -72,7 +72,7 @@ RUN keytool -genkeypair \
     -keystore /etc/trino/conf/keystore.jks \
     -keypass password \
     -storepass password \
-    -dname "CN=trino-coordinator, OU=, O=, L=, S=, C=" \
+    -dname "OU=, O=, L=, S=, C=" \
     -validity 100000
 RUN chmod 644 /etc/trino/conf/keystore.jks
 

--- a/testing/cdh5.12-hive-kerberized/Dockerfile
+++ b/testing/cdh5.12-hive-kerberized/Dockerfile
@@ -50,29 +50,29 @@ RUN chown hive:hadoop /etc/hive/conf/hive.keytab \
 # YARN SECURITY SETTINGS
 RUN chmod 6050 /etc/hadoop/conf/container-executor.cfg
 
-# CREATE PRESTO PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker-1.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker-2.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/presto-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-client/presto-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/presto-master.docker.cluster@LABS.TERADATA.COM" \
+# CREATE TRINO PRINCIPAL AND KEYTAB
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-master.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-1.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-2.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-master.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-master.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-master.docker.cluster@LABS.TERADATA.COM" \
   && mkdir -p /etc/trino/conf \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/presto-server.keytab presto-server/presto-master.docker.cluster presto-server/presto-worker.docker.cluster presto-server/presto-worker-1.docker.cluster presto-server/presto-worker-2.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/presto-server-HTTP.keytab HTTP/presto-master.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/presto-client.keytab presto-client/presto-master.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/hive-presto-master.keytab hive/presto-master.docker.cluster"
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server.keytab trino-server/trino-master.docker.cluster trino-server/trino-worker.docker.cluster trino-server/trino-worker-1.docker.cluster trino-server/trino-worker-2.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server-HTTP.keytab HTTP/trino-master.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-client.keytab trino-client/trino-master.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/hive-trino-master.keytab hive/trino-master.docker.cluster"
 RUN chmod 644 /etc/trino/conf/*.keytab
 
 # CREATE SSL KEYSTORE
 RUN keytool -genkeypair \
-    -alias presto \
+    -alias trino \
     -keyalg RSA \
     -keystore /etc/trino/conf/keystore.jks \
     -keypass password \
     -storepass password \
-    -dname "CN=presto-master, OU=, O=, L=, S=, C=" \
+    -dname "CN=trino-master, OU=, O=, L=, S=, C=" \
     -validity 100000
 RUN chmod 644 /etc/trino/conf/keystore.jks
 

--- a/testing/cdh5.12-hive-kerberized/Dockerfile
+++ b/testing/cdh5.12-hive-kerberized/Dockerfile
@@ -51,18 +51,18 @@ RUN chown hive:hadoop /etc/hive/conf/hive.keytab \
 RUN chmod 6050 /etc/hadoop/conf/container-executor.cfg
 
 # CREATE TRINO PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-master.docker.cluster@LABS.TERADATA.COM" \
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
   && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker.docker.cluster@LABS.TERADATA.COM" \
   && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-1.docker.cluster@LABS.TERADATA.COM" \
   && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-2.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-master.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
   && mkdir -p /etc/trino/conf \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server.keytab trino-server/trino-master.docker.cluster trino-server/trino-worker.docker.cluster trino-server/trino-worker-1.docker.cluster trino-server/trino-worker-2.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server-HTTP.keytab HTTP/trino-master.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-client.keytab trino-client/trino-master.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/hive-trino-master.keytab hive/trino-master.docker.cluster"
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server.keytab trino-server/trino-coordinator.docker.cluster trino-server/trino-worker.docker.cluster trino-server/trino-worker-1.docker.cluster trino-server/trino-worker-2.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server-HTTP.keytab HTTP/trino-coordinator.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-client.keytab trino-client/trino-coordinator.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/hive-trino-coordinator.keytab hive/trino-coordinator.docker.cluster"
 RUN chmod 644 /etc/trino/conf/*.keytab
 
 # CREATE SSL KEYSTORE
@@ -72,7 +72,7 @@ RUN keytool -genkeypair \
     -keystore /etc/trino/conf/keystore.jks \
     -keypass password \
     -storepass password \
-    -dname "CN=trino-master, OU=, O=, L=, S=, C=" \
+    -dname "CN=trino-coordinator, OU=, O=, L=, S=, C=" \
     -validity 100000
 RUN chmod 644 /etc/trino/conf/keystore.jks
 

--- a/testing/cdh5.12-hive-kerberized/files/etc/krb5.conf
+++ b/testing/cdh5.12-hive-kerberized/files/etc/krb5.conf
@@ -4,13 +4,13 @@
  admin_server = FILE:/var/log/kadmind.log
 
 [libdefaults]
- default_realm = LABS.TERADATA.COM
+ default_realm = LABS.TRINO.IO
  dns_lookup_realm = false
  dns_lookup_kdc = false
  forwardable = true
 
 [realms]
- LABS.TERADATA.COM = {
+ LABS.TRINO.IO = {
   kdc = hadoop-master
   admin_server = hadoop-master
  }

--- a/testing/cdh5.12-hive-kerberized/files/etc/krb5.conf
+++ b/testing/cdh5.12-hive-kerberized/files/etc/krb5.conf
@@ -11,6 +11,6 @@
 
 [realms]
  LABS.TRINO.IO = {
-  kdc = hadoop-master
-  admin_server = hadoop-master
+  kdc = hadoop
+  admin_server = hadoop
  }

--- a/testing/cdh5.12-hive-kerberized/files/etc/supervisord.d/kdc.conf
+++ b/testing/cdh5.12-hive-kerberized/files/etc/supervisord.d/kdc.conf
@@ -1,5 +1,5 @@
 [program:krb5kdc]
-command=/bin/bash -c "exec /usr/sbin/krb5kdc -r LABS.TERADATA.COM -P /var/run/krb5kdc.pid -n"
+command=/bin/bash -c "exec /usr/sbin/krb5kdc -r LABS.TRINO.IO -P /var/run/krb5kdc.pid -n"
 autostart=true
 autorestart=true
 redirect_stderr=true
@@ -7,7 +7,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:kadmind]
-command=/bin/bash -c "exec /usr/sbin/kadmind -r LABS.TERADATA.COM -P /var/run/kadmind.pid -nofork"
+command=/bin/bash -c "exec /usr/sbin/kadmind -r LABS.TRINO.IO -P /var/run/kadmind.pid -nofork"
 autostart=true
 autorestart=true
 redirect_stderr=true

--- a/testing/cdh5.12-hive-kerberized/files/overrides/etc/hadoop/conf/hdfs-site.xml
+++ b/testing/cdh5.12-hive-kerberized/files/overrides/etc/hadoop/conf/hdfs-site.xml
@@ -29,12 +29,12 @@
 
     <property>
         <name>dfs.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
+        <value>hdfs/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>
         <name>dfs.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
+        <value>HTTP/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- Secondary NameNode security config -->
@@ -45,12 +45,12 @@
 
     <property>
         <name>dfs.secondary.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
+        <value>hdfs/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>
         <name>dfs.secondary.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
+        <value>HTTP/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- DataNode security config -->
@@ -61,7 +61,7 @@
 
     <property>
         <name>dfs.datanode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
+        <value>hdfs/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- WebHDFS security config -->
@@ -73,7 +73,7 @@
     <!-- Web Authentication config -->
     <property>
         <name>dfs.web.authentication.kerberos.principal</name>
-        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
+        <value>HTTP/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>

--- a/testing/cdh5.12-hive-kerberized/files/overrides/etc/hadoop/conf/hdfs-site.xml
+++ b/testing/cdh5.12-hive-kerberized/files/overrides/etc/hadoop/conf/hdfs-site.xml
@@ -29,12 +29,12 @@
 
     <property>
         <name>dfs.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>
         <name>dfs.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master@LABS.TERADATA.COM</value>
+        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- Secondary NameNode security config -->
@@ -45,12 +45,12 @@
 
     <property>
         <name>dfs.secondary.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>
         <name>dfs.secondary.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master@LABS.TERADATA.COM</value>
+        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- DataNode security config -->
@@ -61,7 +61,7 @@
 
     <property>
         <name>dfs.datanode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- WebHDFS security config -->
@@ -73,7 +73,7 @@
     <!-- Web Authentication config -->
     <property>
         <name>dfs.web.authentication.kerberos.principal</name>
-        <value>HTTP/hadoop-master@LABS.TERADATA.COM</value>
+        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>

--- a/testing/cdh5.12-hive-kerberized/files/overrides/etc/hadoop/conf/mapred-site.xml
+++ b/testing/cdh5.12-hive-kerberized/files/overrides/etc/hadoop/conf/mapred-site.xml
@@ -25,13 +25,13 @@
 
     <property>
         <name>mapreduce.jobhistory.principal</name>
-        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
+        <value>mapred/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- JobTracker security configs -->
     <property>
         <name>mapreduce.jobtracker.kerberos.principal</name>
-        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
+        <value>mapred/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>
@@ -42,7 +42,7 @@
     <!-- TaskTracker security configs -->
     <property>
         <name>mapreduce.tasktracker.kerberos.principal</name>
-        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
+        <value>mapred/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>

--- a/testing/cdh5.12-hive-kerberized/files/overrides/etc/hadoop/conf/mapred-site.xml
+++ b/testing/cdh5.12-hive-kerberized/files/overrides/etc/hadoop/conf/mapred-site.xml
@@ -25,13 +25,13 @@
 
     <property>
         <name>mapreduce.jobhistory.principal</name>
-        <value>mapred/hadoop-master@LABS.TERADATA.COM</value>
+        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- JobTracker security configs -->
     <property>
         <name>mapreduce.jobtracker.kerberos.principal</name>
-        <value>mapred/hadoop-master@LABS.TERADATA.COM</value>
+        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>
@@ -42,7 +42,7 @@
     <!-- TaskTracker security configs -->
     <property>
         <name>mapreduce.tasktracker.kerberos.principal</name>
-        <value>mapred/hadoop-master@LABS.TERADATA.COM</value>
+        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>

--- a/testing/cdh5.12-hive-kerberized/files/overrides/etc/hadoop/conf/yarn-site.xml
+++ b/testing/cdh5.12-hive-kerberized/files/overrides/etc/hadoop/conf/yarn-site.xml
@@ -26,7 +26,7 @@
 
     <property>
         <name>yarn.resourcemanager.principal</name>
-        <value>yarn/hadoop-master@LABS.TRINO.IO</value>
+        <value>yarn/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- NodeManager security configs -->
@@ -37,7 +37,7 @@
 
     <property>
         <name>yarn.nodemanager.principal</name>
-        <value>yarn/hadoop-master@LABS.TRINO.IO</value>
+        <value>yarn/hadoop@LABS.TRINO.IO</value>
     </property>
     
     <property>

--- a/testing/cdh5.12-hive-kerberized/files/overrides/etc/hadoop/conf/yarn-site.xml
+++ b/testing/cdh5.12-hive-kerberized/files/overrides/etc/hadoop/conf/yarn-site.xml
@@ -26,7 +26,7 @@
 
     <property>
         <name>yarn.resourcemanager.principal</name>
-        <value>yarn/hadoop-master@LABS.TERADATA.COM</value>
+        <value>yarn/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- NodeManager security configs -->
@@ -37,7 +37,7 @@
 
     <property>
         <name>yarn.nodemanager.principal</name>
-        <value>yarn/hadoop-master@LABS.TERADATA.COM</value>
+        <value>yarn/hadoop-master@LABS.TRINO.IO</value>
     </property>
     
     <property>

--- a/testing/cdh5.12-hive-kerberized/files/overrides/etc/hive/conf/hive-site.xml
+++ b/testing/cdh5.12-hive-kerberized/files/overrides/etc/hive/conf/hive-site.xml
@@ -30,7 +30,7 @@
 
     <property>
         <name>hive.server2.authentication.kerberos.principal</name>
-        <value>hive/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hive/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>
@@ -50,7 +50,7 @@
 
     <property>
         <name>hive.metastore.kerberos.principal</name>
-        <value>hive/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hive/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- Enable SQL based authorization -->

--- a/testing/cdh5.12-hive-kerberized/files/overrides/etc/hive/conf/hive-site.xml
+++ b/testing/cdh5.12-hive-kerberized/files/overrides/etc/hive/conf/hive-site.xml
@@ -30,7 +30,7 @@
 
     <property>
         <name>hive.server2.authentication.kerberos.principal</name>
-        <value>hive/hadoop-master@LABS.TRINO.IO</value>
+        <value>hive/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>
@@ -50,7 +50,7 @@
 
     <property>
         <name>hive.metastore.kerberos.principal</name>
-        <value>hive/hadoop-master@LABS.TRINO.IO</value>
+        <value>hive/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- Enable SQL based authorization -->

--- a/testing/cdh5.12-hive-kerberized/files/var/kerberos/krb5kdc/kadm5.acl
+++ b/testing/cdh5.12-hive-kerberized/files/var/kerberos/krb5kdc/kadm5.acl
@@ -1,1 +1,1 @@
-*/admin@LABS.TERADATA.COM	*
+*/admin@LABS.TRINO.IO	*

--- a/testing/cdh5.12-hive-kerberized/files/var/kerberos/krb5kdc/kdc.conf
+++ b/testing/cdh5.12-hive-kerberized/files/var/kerberos/krb5kdc/kdc.conf
@@ -3,7 +3,7 @@
  kdc_tcp_ports = 88
 
 [realms]
- LABS.TERADATA.COM = {
+ LABS.TRINO.IO = {
   #master_key_type = aes256-cts
   acl_file = /var/kerberos/krb5kdc/kadm5.acl
   dict_file = /usr/share/dict/words

--- a/testing/cdh5.12-hive/files/etc/hadoop/conf/core-site.xml
+++ b/testing/cdh5.12-hive/files/etc/hadoop/conf/core-site.xml
@@ -19,7 +19,7 @@
 
     <property>
         <name>fs.defaultFS</name>
-        <value>hdfs://hadoop-master:9000</value>
+        <value>hdfs://hadoop:9000</value>
     </property>
 
     <!-- OOZIE proxy user setting -->

--- a/testing/cdh5.12-hive/files/etc/hadoop/conf/hdfs-site.xml
+++ b/testing/cdh5.12-hive/files/etc/hadoop/conf/hdfs-site.xml
@@ -27,7 +27,7 @@
 
     <property>
         <name>fs.viewfs.mounttable.hadoop-viewfs.link./default</name>
-        <value>hdfs://hadoop-master:9000/user/hive/warehouse</value>
+        <value>hdfs://hadoop:9000/user/hive/warehouse</value>
     </property>
 
 </configuration>

--- a/testing/cdh5.12-hive/files/etc/hadoop/conf/mapred-site.xml
+++ b/testing/cdh5.12-hive/files/etc/hadoop/conf/mapred-site.xml
@@ -19,17 +19,17 @@
 
     <property>
         <name>mapred.job.tracker</name>
-        <value>hadoop-master:8021</value>
+        <value>hadoop:8021</value>
     </property>
 
     <property>
         <name>mapreduce.jobhistory.address</name>
-        <value>hadoop-master:10020</value>
+        <value>hadoop:10020</value>
     </property>
 
     <property>
         <name>mapreduce.jobhistory.webapp.address</name>
-        <value>hadoop-master:19888</value>
+        <value>hadoop:19888</value>
     </property>
 
     <property>

--- a/testing/cdh5.12-hive/files/etc/hadoop/conf/yarn-site.xml
+++ b/testing/cdh5.12-hive/files/etc/hadoop/conf/yarn-site.xml
@@ -73,7 +73,7 @@
 
     <property>
         <name>yarn.resourcemanager.hostname</name>
-        <value>hadoop-master</value>
+        <value>hadoop</value>
     </property>
 
     <property>
@@ -103,7 +103,7 @@
 
     <property>
         <name>yarn.log.server.url</name>
-        <value>http://hadoop-master:19888/jobhistory/logs</value>
+        <value>http://hadoop:19888/jobhistory/logs</value>
     </property>
 
 </configuration>

--- a/testing/cdh5.12-hive/files/root/setup.sh
+++ b/testing/cdh5.12-hive/files/root/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 # make file system hostname resolvable
-echo "127.0.0.1 hadoop-master" >> /etc/hosts
+echo "127.0.0.1 hadoop" >> /etc/hosts
 
 # format namenode
 chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/

--- a/testing/cdh5.15-hive-kerberized-kms/Dockerfile
+++ b/testing/cdh5.15-hive-kerberized-kms/Dockerfile
@@ -26,8 +26,8 @@ RUN set -xeu && \
     for username in alice bob charlie; do \
         groupadd "${username}_group" && \
         useradd -g "${username}_group" "${username}" && \
-        /usr/sbin/kadmin.local -q "addprinc -randkey ${username}/hadoop-master@LABS.TRINO.IO" && \
-        /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hive/conf/${username}.keytab ${username}/hadoop-master"; \
+        /usr/sbin/kadmin.local -q "addprinc -randkey ${username}/hadoop@LABS.TRINO.IO" && \
+        /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hive/conf/${username}.keytab ${username}/hadoop"; \
     done && \
     echo OK
 

--- a/testing/cdh5.15-hive-kerberized-kms/Dockerfile
+++ b/testing/cdh5.15-hive-kerberized-kms/Dockerfile
@@ -26,7 +26,7 @@ RUN set -xeu && \
     for username in alice bob charlie; do \
         groupadd "${username}_group" && \
         useradd -g "${username}_group" "${username}" && \
-        /usr/sbin/kadmin.local -q "addprinc -randkey ${username}/hadoop-master@LABS.TERADATA.COM" && \
+        /usr/sbin/kadmin.local -q "addprinc -randkey ${username}/hadoop-master@LABS.TRINO.IO" && \
         /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hive/conf/${username}.keytab ${username}/hadoop-master"; \
     done && \
     echo OK

--- a/testing/cdh5.15-hive-kerberized-kms/files/etc/hadoop-kms/conf/core-site.xml
+++ b/testing/cdh5.15-hive-kerberized-kms/files/etc/hadoop-kms/conf/core-site.xml
@@ -3,7 +3,7 @@
 
     <property>
         <name>fs.defaultFS</name>
-        <value>hdfs://hadoop-master:9000</value>
+        <value>hdfs://hadoop:9000</value>
     </property>
 
 </configuration>

--- a/testing/cdh5.15-hive-kerberized-kms/files/etc/hadoop-kms/conf/kms-site.xml
+++ b/testing/cdh5.15-hive-kerberized-kms/files/etc/hadoop-kms/conf/kms-site.xml
@@ -18,7 +18,7 @@
 
     <property>
         <name>hadoop.kms.authentication.kerberos.principal</name>
-        <value>HTTP/hadoop-master</value>
+        <value>HTTP/hadoop</value>
     </property>
 
     <property>

--- a/testing/cdh5.15-hive-kerberized-kms/files/etc/hadoop/conf/core-site.xml
+++ b/testing/cdh5.15-hive-kerberized-kms/files/etc/hadoop/conf/core-site.xml
@@ -3,7 +3,7 @@
 
     <property>
         <name>fs.defaultFS</name>
-        <value>hdfs://hadoop-master:9000</value>
+        <value>hdfs://hadoop:9000</value>
     </property>
 
     <!-- HTTPFS proxy user setting -->
@@ -64,12 +64,12 @@
     <!-- KMS -->
     <property>
         <name>hadoop.security.key.provider.path</name>
-        <value>kms://http@hadoop-master:16000/kms</value>
+        <value>kms://http@hadoop:16000/kms</value>
     </property>
 
     <property>
         <name>dfs.encryption.key.provider.uri</name>
-        <value>kms://http@hadoop-master:16000/kms</value>
+        <value>kms://http@hadoop:16000/kms</value>
     </property>
 
 </configuration>

--- a/testing/cdh5.15-hive-kerberized-kms/files/etc/hadoop/conf/hdfs-site.xml
+++ b/testing/cdh5.15-hive-kerberized-kms/files/etc/hadoop/conf/hdfs-site.xml
@@ -27,7 +27,7 @@
 
     <property>
         <name>fs.viewfs.mounttable.hadoop-viewfs.link./default</name>
-        <value>hdfs://hadoop-master:9000/user/hive/warehouse</value>
+        <value>hdfs://hadoop:9000/user/hive/warehouse</value>
     </property>
 
     <!-- General HDFS security config -->
@@ -45,12 +45,12 @@
 
     <property>
         <name>dfs.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
+        <value>hdfs/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>
         <name>dfs.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
+        <value>HTTP/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- Secondary NameNode security config -->
@@ -62,12 +62,12 @@
 
     <property>
         <name>dfs.secondary.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
+        <value>hdfs/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>
         <name>dfs.secondary.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
+        <value>HTTP/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- DataNode security config -->
@@ -79,7 +79,7 @@
 
     <property>
         <name>dfs.datanode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
+        <value>hdfs/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- WebHDFS security config -->
@@ -91,7 +91,7 @@
     <!-- Web Authentication config -->
     <property>
         <name>dfs.web.authentication.kerberos.principal</name>
-        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
+        <value>HTTP/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>

--- a/testing/cdh5.15-hive-kerberized-kms/files/etc/hadoop/conf/hdfs-site.xml
+++ b/testing/cdh5.15-hive-kerberized-kms/files/etc/hadoop/conf/hdfs-site.xml
@@ -45,12 +45,12 @@
 
     <property>
         <name>dfs.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>
         <name>dfs.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master@LABS.TERADATA.COM</value>
+        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- Secondary NameNode security config -->
@@ -62,12 +62,12 @@
 
     <property>
         <name>dfs.secondary.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>
         <name>dfs.secondary.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master@LABS.TERADATA.COM</value>
+        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- DataNode security config -->
@@ -79,7 +79,7 @@
 
     <property>
         <name>dfs.datanode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- WebHDFS security config -->
@@ -91,7 +91,7 @@
     <!-- Web Authentication config -->
     <property>
         <name>dfs.web.authentication.kerberos.principal</name>
-        <value>HTTP/hadoop-master@LABS.TERADATA.COM</value>
+        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>

--- a/testing/cdh5.15-hive-kerberized-kms/files/etc/hive/conf/hive-site.xml
+++ b/testing/cdh5.15-hive-kerberized-kms/files/etc/hive/conf/hive-site.xml
@@ -59,7 +59,7 @@
 
     <property>
         <name>hive.server2.authentication.kerberos.principal</name>
-        <value>hive/hadoop-master@LABS.TRINO.IO</value>
+        <value>hive/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>
@@ -79,7 +79,7 @@
 
     <property>
         <name>hive.metastore.kerberos.principal</name>
-        <value>hive/hadoop-master@LABS.TRINO.IO</value>
+        <value>hive/hadoop@LABS.TRINO.IO</value>
     </property>
 
 </configuration>

--- a/testing/cdh5.15-hive-kerberized-kms/files/etc/hive/conf/hive-site.xml
+++ b/testing/cdh5.15-hive-kerberized-kms/files/etc/hive/conf/hive-site.xml
@@ -59,7 +59,7 @@
 
     <property>
         <name>hive.server2.authentication.kerberos.principal</name>
-        <value>hive/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hive/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>
@@ -79,7 +79,7 @@
 
     <property>
         <name>hive.metastore.kerberos.principal</name>
-        <value>hive/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hive/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
 </configuration>

--- a/testing/cdh5.15-hive-kerberized-kms/files/root/setup_kms.sh
+++ b/testing/cdh5.15-hive-kerberized-kms/files/root/setup_kms.sh
@@ -23,7 +23,7 @@ function retry() {
 echo 127.0.0.2 `# must be different than localhost IP` hadoop-master >> /etc/hosts
 supervisord -c /etc/supervisord.conf &
 
-retry kinit -kt /etc/hadoop/conf/hdfs.keytab hdfs/hadoop-master@LABS.TERADATA.COM
+retry kinit -kt /etc/hadoop/conf/hdfs.keytab hdfs/hadoop-master@LABS.TRINO.IO
 retry hdfs dfsadmin -safemode leave
 
 set -x

--- a/testing/cdh5.15-hive-kerberized-kms/files/root/setup_kms.sh
+++ b/testing/cdh5.15-hive-kerberized-kms/files/root/setup_kms.sh
@@ -20,10 +20,10 @@ function retry() {
   return ${EXIT_CODE}
 }
 
-echo 127.0.0.2 `# must be different than localhost IP` hadoop-master >> /etc/hosts
+echo 127.0.0.2 `# must be different than localhost IP` hadoop >> /etc/hosts
 supervisord -c /etc/supervisord.conf &
 
-retry kinit -kt /etc/hadoop/conf/hdfs.keytab hdfs/hadoop-master@LABS.TRINO.IO
+retry kinit -kt /etc/hadoop/conf/hdfs.keytab hdfs/hadoop@LABS.TRINO.IO
 retry hdfs dfsadmin -safemode leave
 
 set -x

--- a/testing/cdh5.15-hive-kerberized/Dockerfile
+++ b/testing/cdh5.15-hive-kerberized/Dockerfile
@@ -25,16 +25,16 @@ RUN /usr/local/bin/apply-all-site-xml-overrides /overrides
 RUN /usr/sbin/kdb5_util create -s -P password
 
 # ADD HADOOP PRINCIPALS
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey hdfs/hadoop-master@LABS.TRINO.IO" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey mapred/hadoop-master@LABS.TRINO.IO" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey yarn/hadoop-master@LABS.TRINO.IO" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/hadoop-master@LABS.TRINO.IO" 
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hdfs/hadoop@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey mapred/hadoop@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey yarn/hadoop@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/hadoop@LABS.TRINO.IO" 
 
 # CREATE HADOOP KEYTAB FILES
-RUN /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/hdfs.keytab hdfs/hadoop-master HTTP/hadoop-master" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/mapred.keytab mapred/hadoop-master HTTP/hadoop-master" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/yarn.keytab yarn/hadoop-master HTTP/hadoop-master" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/HTTP.keytab HTTP/hadoop-master"
+RUN /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/hdfs.keytab hdfs/hadoop HTTP/hadoop" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/mapred.keytab mapred/hadoop HTTP/hadoop" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/yarn.keytab yarn/hadoop HTTP/hadoop" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/HTTP.keytab HTTP/hadoop"
 RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs.keytab \
   && chown mapred:hadoop /etc/hadoop/conf/mapred.keytab \
   && chown yarn:hadoop /etc/hadoop/conf/yarn.keytab \
@@ -42,8 +42,8 @@ RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs.keytab \
   && chmod 644 /etc/hadoop/conf/*.keytab
 
 # CREATE HIVE PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop-master@LABS.TRINO.IO" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hive/conf/hive.keytab hive/hadoop-master"
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hive/conf/hive.keytab hive/hadoop"
 RUN chown hive:hadoop /etc/hive/conf/hive.keytab \
   && chmod 644 /etc/hive/conf/hive.keytab
 

--- a/testing/cdh5.15-hive-kerberized/Dockerfile
+++ b/testing/cdh5.15-hive-kerberized/Dockerfile
@@ -25,10 +25,10 @@ RUN /usr/local/bin/apply-all-site-xml-overrides /overrides
 RUN /usr/sbin/kdb5_util create -s -P password
 
 # ADD HADOOP PRINCIPALS
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey hdfs/hadoop-master@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey mapred/hadoop-master@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey yarn/hadoop-master@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/hadoop-master@LABS.TERADATA.COM" 
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hdfs/hadoop-master@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey mapred/hadoop-master@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey yarn/hadoop-master@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/hadoop-master@LABS.TRINO.IO" 
 
 # CREATE HADOOP KEYTAB FILES
 RUN /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/hdfs.keytab hdfs/hadoop-master HTTP/hadoop-master" \
@@ -42,7 +42,7 @@ RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs.keytab \
   && chmod 644 /etc/hadoop/conf/*.keytab
 
 # CREATE HIVE PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop-master@LABS.TERADATA.COM" \
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop-master@LABS.TRINO.IO" \
   && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hive/conf/hive.keytab hive/hadoop-master"
 RUN chown hive:hadoop /etc/hive/conf/hive.keytab \
   && chmod 644 /etc/hive/conf/hive.keytab
@@ -51,13 +51,13 @@ RUN chown hive:hadoop /etc/hive/conf/hive.keytab \
 RUN chmod 6050 /etc/hadoop/conf/container-executor.cfg
 
 # CREATE TRINO PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-1.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-2.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-coordinator.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-1.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-2.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-coordinator.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-coordinator.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-coordinator.docker.cluster@LABS.TRINO.IO" \
   && mkdir -p /etc/trino/conf \
   && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server.keytab trino-server/trino-coordinator.docker.cluster trino-server/trino-worker.docker.cluster trino-server/trino-worker-1.docker.cluster trino-server/trino-worker-2.docker.cluster" \
   && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server-HTTP.keytab HTTP/trino-coordinator.docker.cluster" \

--- a/testing/cdh5.15-hive-kerberized/Dockerfile
+++ b/testing/cdh5.15-hive-kerberized/Dockerfile
@@ -72,7 +72,7 @@ RUN keytool -genkeypair \
     -keystore /etc/trino/conf/keystore.jks \
     -keypass password \
     -storepass password \
-    -dname "CN=trino-coordinator, OU=, O=, L=, S=, C=" \
+    -dname "OU=, O=, L=, S=, C=" \
     -validity 100000
 RUN chmod 644 /etc/trino/conf/keystore.jks
 

--- a/testing/cdh5.15-hive-kerberized/Dockerfile
+++ b/testing/cdh5.15-hive-kerberized/Dockerfile
@@ -50,29 +50,29 @@ RUN chown hive:hadoop /etc/hive/conf/hive.keytab \
 # YARN SECURITY SETTINGS
 RUN chmod 6050 /etc/hadoop/conf/container-executor.cfg
 
-# CREATE PRESTO PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker-1.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker-2.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/presto-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-client/presto-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/presto-master.docker.cluster@LABS.TERADATA.COM" \
+# CREATE TRINO PRINCIPAL AND KEYTAB
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-master.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-1.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-2.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-master.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-master.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-master.docker.cluster@LABS.TERADATA.COM" \
   && mkdir -p /etc/trino/conf \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/presto-server.keytab presto-server/presto-master.docker.cluster presto-server/presto-worker.docker.cluster presto-server/presto-worker-1.docker.cluster presto-server/presto-worker-2.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/presto-server-HTTP.keytab HTTP/presto-master.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/presto-client.keytab presto-client/presto-master.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/hive-presto-master.keytab hive/presto-master.docker.cluster"
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server.keytab trino-server/trino-master.docker.cluster trino-server/trino-worker.docker.cluster trino-server/trino-worker-1.docker.cluster trino-server/trino-worker-2.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server-HTTP.keytab HTTP/trino-master.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-client.keytab trino-client/trino-master.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/hive-trino-master.keytab hive/trino-master.docker.cluster"
 RUN chmod 644 /etc/trino/conf/*.keytab
 
 # CREATE SSL KEYSTORE
 RUN keytool -genkeypair \
-    -alias presto \
+    -alias trino \
     -keyalg RSA \
     -keystore /etc/trino/conf/keystore.jks \
     -keypass password \
     -storepass password \
-    -dname "CN=presto-master, OU=, O=, L=, S=, C=" \
+    -dname "CN=trino-master, OU=, O=, L=, S=, C=" \
     -validity 100000
 RUN chmod 644 /etc/trino/conf/keystore.jks
 

--- a/testing/cdh5.15-hive-kerberized/Dockerfile
+++ b/testing/cdh5.15-hive-kerberized/Dockerfile
@@ -51,18 +51,18 @@ RUN chown hive:hadoop /etc/hive/conf/hive.keytab \
 RUN chmod 6050 /etc/hadoop/conf/container-executor.cfg
 
 # CREATE TRINO PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-master.docker.cluster@LABS.TERADATA.COM" \
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
   && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker.docker.cluster@LABS.TERADATA.COM" \
   && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-1.docker.cluster@LABS.TERADATA.COM" \
   && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-2.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-master.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
   && mkdir -p /etc/trino/conf \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server.keytab trino-server/trino-master.docker.cluster trino-server/trino-worker.docker.cluster trino-server/trino-worker-1.docker.cluster trino-server/trino-worker-2.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server-HTTP.keytab HTTP/trino-master.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-client.keytab trino-client/trino-master.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/hive-trino-master.keytab hive/trino-master.docker.cluster"
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server.keytab trino-server/trino-coordinator.docker.cluster trino-server/trino-worker.docker.cluster trino-server/trino-worker-1.docker.cluster trino-server/trino-worker-2.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server-HTTP.keytab HTTP/trino-coordinator.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-client.keytab trino-client/trino-coordinator.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/hive-trino-coordinator.keytab hive/trino-coordinator.docker.cluster"
 RUN chmod 644 /etc/trino/conf/*.keytab
 
 # CREATE SSL KEYSTORE
@@ -72,7 +72,7 @@ RUN keytool -genkeypair \
     -keystore /etc/trino/conf/keystore.jks \
     -keypass password \
     -storepass password \
-    -dname "CN=trino-master, OU=, O=, L=, S=, C=" \
+    -dname "CN=trino-coordinator, OU=, O=, L=, S=, C=" \
     -validity 100000
 RUN chmod 644 /etc/trino/conf/keystore.jks
 

--- a/testing/cdh5.15-hive-kerberized/files/etc/krb5.conf
+++ b/testing/cdh5.15-hive-kerberized/files/etc/krb5.conf
@@ -4,13 +4,13 @@
  admin_server = FILE:/var/log/kadmind.log
 
 [libdefaults]
- default_realm = LABS.TERADATA.COM
+ default_realm = LABS.TRINO.IO
  dns_lookup_realm = false
  dns_lookup_kdc = false
  forwardable = true
 
 [realms]
- LABS.TERADATA.COM = {
+ LABS.TRINO.IO = {
   kdc = hadoop-master
   admin_server = hadoop-master
  }

--- a/testing/cdh5.15-hive-kerberized/files/etc/krb5.conf
+++ b/testing/cdh5.15-hive-kerberized/files/etc/krb5.conf
@@ -11,6 +11,6 @@
 
 [realms]
  LABS.TRINO.IO = {
-  kdc = hadoop-master
-  admin_server = hadoop-master
+  kdc = hadoop
+  admin_server = hadoop
  }

--- a/testing/cdh5.15-hive-kerberized/files/etc/supervisord.d/kdc.conf
+++ b/testing/cdh5.15-hive-kerberized/files/etc/supervisord.d/kdc.conf
@@ -1,5 +1,5 @@
 [program:krb5kdc]
-command=/bin/bash -c "exec /usr/sbin/krb5kdc -r LABS.TERADATA.COM -P /var/run/krb5kdc.pid -n"
+command=/bin/bash -c "exec /usr/sbin/krb5kdc -r LABS.TRINO.IO -P /var/run/krb5kdc.pid -n"
 autostart=true
 autorestart=true
 redirect_stderr=true
@@ -7,7 +7,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:kadmind]
-command=/bin/bash -c "exec /usr/sbin/kadmind -r LABS.TERADATA.COM -P /var/run/kadmind.pid -nofork"
+command=/bin/bash -c "exec /usr/sbin/kadmind -r LABS.TRINO.IO -P /var/run/kadmind.pid -nofork"
 autostart=true
 autorestart=true
 redirect_stderr=true

--- a/testing/cdh5.15-hive-kerberized/files/overrides/etc/hadoop/conf/hdfs-site.xml
+++ b/testing/cdh5.15-hive-kerberized/files/overrides/etc/hadoop/conf/hdfs-site.xml
@@ -29,12 +29,12 @@
 
     <property>
         <name>dfs.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
+        <value>hdfs/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>
         <name>dfs.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
+        <value>HTTP/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- Secondary NameNode security config -->
@@ -45,12 +45,12 @@
 
     <property>
         <name>dfs.secondary.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
+        <value>hdfs/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>
         <name>dfs.secondary.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
+        <value>HTTP/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- DataNode security config -->
@@ -61,7 +61,7 @@
 
     <property>
         <name>dfs.datanode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
+        <value>hdfs/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- WebHDFS security config -->
@@ -73,7 +73,7 @@
     <!-- Web Authentication config -->
     <property>
         <name>dfs.web.authentication.kerberos.principal</name>
-        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
+        <value>HTTP/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>

--- a/testing/cdh5.15-hive-kerberized/files/overrides/etc/hadoop/conf/hdfs-site.xml
+++ b/testing/cdh5.15-hive-kerberized/files/overrides/etc/hadoop/conf/hdfs-site.xml
@@ -29,12 +29,12 @@
 
     <property>
         <name>dfs.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>
         <name>dfs.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master@LABS.TERADATA.COM</value>
+        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- Secondary NameNode security config -->
@@ -45,12 +45,12 @@
 
     <property>
         <name>dfs.secondary.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>
         <name>dfs.secondary.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master@LABS.TERADATA.COM</value>
+        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- DataNode security config -->
@@ -61,7 +61,7 @@
 
     <property>
         <name>dfs.datanode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- WebHDFS security config -->
@@ -73,7 +73,7 @@
     <!-- Web Authentication config -->
     <property>
         <name>dfs.web.authentication.kerberos.principal</name>
-        <value>HTTP/hadoop-master@LABS.TERADATA.COM</value>
+        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>

--- a/testing/cdh5.15-hive-kerberized/files/overrides/etc/hadoop/conf/mapred-site.xml
+++ b/testing/cdh5.15-hive-kerberized/files/overrides/etc/hadoop/conf/mapred-site.xml
@@ -25,13 +25,13 @@
 
     <property>
         <name>mapreduce.jobhistory.principal</name>
-        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
+        <value>mapred/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- JobTracker security configs -->
     <property>
         <name>mapreduce.jobtracker.kerberos.principal</name>
-        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
+        <value>mapred/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>
@@ -42,7 +42,7 @@
     <!-- TaskTracker security configs -->
     <property>
         <name>mapreduce.tasktracker.kerberos.principal</name>
-        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
+        <value>mapred/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>

--- a/testing/cdh5.15-hive-kerberized/files/overrides/etc/hadoop/conf/mapred-site.xml
+++ b/testing/cdh5.15-hive-kerberized/files/overrides/etc/hadoop/conf/mapred-site.xml
@@ -25,13 +25,13 @@
 
     <property>
         <name>mapreduce.jobhistory.principal</name>
-        <value>mapred/hadoop-master@LABS.TERADATA.COM</value>
+        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- JobTracker security configs -->
     <property>
         <name>mapreduce.jobtracker.kerberos.principal</name>
-        <value>mapred/hadoop-master@LABS.TERADATA.COM</value>
+        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>
@@ -42,7 +42,7 @@
     <!-- TaskTracker security configs -->
     <property>
         <name>mapreduce.tasktracker.kerberos.principal</name>
-        <value>mapred/hadoop-master@LABS.TERADATA.COM</value>
+        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>

--- a/testing/cdh5.15-hive-kerberized/files/overrides/etc/hadoop/conf/yarn-site.xml
+++ b/testing/cdh5.15-hive-kerberized/files/overrides/etc/hadoop/conf/yarn-site.xml
@@ -26,7 +26,7 @@
 
     <property>
         <name>yarn.resourcemanager.principal</name>
-        <value>yarn/hadoop-master@LABS.TRINO.IO</value>
+        <value>yarn/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- NodeManager security configs -->
@@ -37,7 +37,7 @@
 
     <property>
         <name>yarn.nodemanager.principal</name>
-        <value>yarn/hadoop-master@LABS.TRINO.IO</value>
+        <value>yarn/hadoop@LABS.TRINO.IO</value>
     </property>
     
     <property>

--- a/testing/cdh5.15-hive-kerberized/files/overrides/etc/hadoop/conf/yarn-site.xml
+++ b/testing/cdh5.15-hive-kerberized/files/overrides/etc/hadoop/conf/yarn-site.xml
@@ -26,7 +26,7 @@
 
     <property>
         <name>yarn.resourcemanager.principal</name>
-        <value>yarn/hadoop-master@LABS.TERADATA.COM</value>
+        <value>yarn/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- NodeManager security configs -->
@@ -37,7 +37,7 @@
 
     <property>
         <name>yarn.nodemanager.principal</name>
-        <value>yarn/hadoop-master@LABS.TERADATA.COM</value>
+        <value>yarn/hadoop-master@LABS.TRINO.IO</value>
     </property>
     
     <property>

--- a/testing/cdh5.15-hive-kerberized/files/overrides/etc/hive/conf/hive-site.xml
+++ b/testing/cdh5.15-hive-kerberized/files/overrides/etc/hive/conf/hive-site.xml
@@ -30,7 +30,7 @@
 
     <property>
         <name>hive.server2.authentication.kerberos.principal</name>
-        <value>hive/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hive/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>
@@ -50,7 +50,7 @@
 
     <property>
         <name>hive.metastore.kerberos.principal</name>
-        <value>hive/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hive/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- Enable SQL based authorization -->

--- a/testing/cdh5.15-hive-kerberized/files/overrides/etc/hive/conf/hive-site.xml
+++ b/testing/cdh5.15-hive-kerberized/files/overrides/etc/hive/conf/hive-site.xml
@@ -30,7 +30,7 @@
 
     <property>
         <name>hive.server2.authentication.kerberos.principal</name>
-        <value>hive/hadoop-master@LABS.TRINO.IO</value>
+        <value>hive/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>
@@ -50,7 +50,7 @@
 
     <property>
         <name>hive.metastore.kerberos.principal</name>
-        <value>hive/hadoop-master@LABS.TRINO.IO</value>
+        <value>hive/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- Enable SQL based authorization -->

--- a/testing/cdh5.15-hive-kerberized/files/var/kerberos/krb5kdc/kadm5.acl
+++ b/testing/cdh5.15-hive-kerberized/files/var/kerberos/krb5kdc/kadm5.acl
@@ -1,1 +1,1 @@
-*/admin@LABS.TERADATA.COM	*
+*/admin@LABS.TRINO.IO	*

--- a/testing/cdh5.15-hive-kerberized/files/var/kerberos/krb5kdc/kdc.conf
+++ b/testing/cdh5.15-hive-kerberized/files/var/kerberos/krb5kdc/kdc.conf
@@ -3,7 +3,7 @@
  kdc_tcp_ports = 88
 
 [realms]
- LABS.TERADATA.COM = {
+ LABS.TRINO.IO = {
   #master_key_type = aes256-cts
   acl_file = /var/kerberos/krb5kdc/kadm5.acl
   dict_file = /usr/share/dict/words

--- a/testing/cdh5.15-hive/files/etc/hadoop/conf/core-site.xml
+++ b/testing/cdh5.15-hive/files/etc/hadoop/conf/core-site.xml
@@ -19,7 +19,7 @@
 
     <property>
         <name>fs.defaultFS</name>
-        <value>hdfs://hadoop-master:9000</value>
+        <value>hdfs://hadoop:9000</value>
     </property>
 
     <!-- OOZIE proxy user setting -->

--- a/testing/cdh5.15-hive/files/etc/hadoop/conf/hdfs-site.xml
+++ b/testing/cdh5.15-hive/files/etc/hadoop/conf/hdfs-site.xml
@@ -27,7 +27,7 @@
 
     <property>
         <name>fs.viewfs.mounttable.hadoop-viewfs.link./default</name>
-        <value>hdfs://hadoop-master:9000/user/hive/warehouse</value>
+        <value>hdfs://hadoop:9000/user/hive/warehouse</value>
     </property>
 
 </configuration>

--- a/testing/cdh5.15-hive/files/etc/hadoop/conf/mapred-site.xml
+++ b/testing/cdh5.15-hive/files/etc/hadoop/conf/mapred-site.xml
@@ -19,17 +19,17 @@
 
     <property>
         <name>mapred.job.tracker</name>
-        <value>hadoop-master:8021</value>
+        <value>hadoop:8021</value>
     </property>
 
     <property>
         <name>mapreduce.jobhistory.address</name>
-        <value>hadoop-master:10020</value>
+        <value>hadoop:10020</value>
     </property>
 
     <property>
         <name>mapreduce.jobhistory.webapp.address</name>
-        <value>hadoop-master:19888</value>
+        <value>hadoop:19888</value>
     </property>
 
     <property>

--- a/testing/cdh5.15-hive/files/etc/hadoop/conf/yarn-site.xml
+++ b/testing/cdh5.15-hive/files/etc/hadoop/conf/yarn-site.xml
@@ -73,7 +73,7 @@
 
     <property>
         <name>yarn.resourcemanager.hostname</name>
-        <value>hadoop-master</value>
+        <value>hadoop</value>
     </property>
 
     <property>
@@ -103,7 +103,7 @@
 
     <property>
         <name>yarn.log.server.url</name>
-        <value>http://hadoop-master:19888/jobhistory/logs</value>
+        <value>http://hadoop:19888/jobhistory/logs</value>
     </property>
 
 </configuration>

--- a/testing/cdh5.15-hive/files/root/setup.sh
+++ b/testing/cdh5.15-hive/files/root/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 # make file system hostname resolvable
-echo "127.0.0.1 hadoop-master" >> /etc/hosts
+echo "127.0.0.1 hadoop" >> /etc/hosts
 
 # format namenode
 chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/

--- a/testing/centos6-oj8-openldap/Dockerfile
+++ b/testing/centos6-oj8-openldap/Dockerfile
@@ -30,7 +30,7 @@ RUN service slapd start && \
 
 # Generate a keystore.
 RUN keytool -genkey -alias coordinator -storepass testldap -keystore /etc/openldap/certs/coordinator.jks \
-    -keypass testldap -keyalg RSA -sigalg SHA1withRSA -dname "CN=trino-master, OU=, O=, L=, S=, C=" -validity 100000
+    -keypass testldap -keyalg RSA -sigalg SHA1withRSA -dname "CN=trino-coordinator, OU=, O=, L=, S=, C=" -validity 100000
 
 # Generate a certificate and CSR for the keystore. CN should match the hostname of trino-coordinator
 RUN keytool -export -alias coordinator -storepass testldap -keystore /etc/openldap/certs/coordinator.jks \

--- a/testing/centos6-oj8-openldap/Dockerfile
+++ b/testing/centos6-oj8-openldap/Dockerfile
@@ -30,7 +30,7 @@ RUN service slapd start && \
 
 # Generate a keystore.
 RUN keytool -genkey -alias coordinator -storepass testldap -keystore /etc/openldap/certs/coordinator.jks \
-    -keypass testldap -keyalg RSA -sigalg SHA1withRSA -dname "CN=trino-coordinator, OU=, O=, L=, S=, C=" -validity 100000
+    -keypass testldap -keyalg RSA -sigalg SHA1withRSA -dname "OU=, O=, L=, S=, C=" -validity 100000
 
 # Generate a certificate and CSR for the keystore. CN should match the hostname of trino-coordinator
 RUN keytool -export -alias coordinator -storepass testldap -keystore /etc/openldap/certs/coordinator.jks \
@@ -40,7 +40,7 @@ RUN keytool -export -alias coordinator -storepass testldap -keystore /etc/openld
 
 # create a test CA and generate caroot.cer( root certificate of the CA ).
 RUN openssl req -new -keyout /etc/openldap/certs/cakey.pem -out /etc/openldap/certs/careq.pem -nodes \
-    -subj "/C=US/ST=Massachusetts/L=Boston/O=Teradata/OU=Finance/CN=teradata" && \
+    -subj "/C=US/ST=Massachusetts/L=Boston/O=Teradata/OU=Finance" && \
     openssl x509 -req -in /etc/openldap/certs/careq.pem -out /etc/openldap/certs/caroot.cer -days 100000 \
     -signkey /etc/openldap/certs/cakey.pem
 

--- a/testing/hdp2.6-hive-kerberized-2/Dockerfile
+++ b/testing/hdp2.6-hive-kerberized-2/Dockerfile
@@ -26,16 +26,16 @@ RUN /usr/local/bin/apply-all-site-xml-overrides /overrides
 RUN /usr/sbin/kdb5_util create -s -P password
 
 # ADD HADOOP PRINCIPALS
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey hdfs/hadoop-master-2@OTHERREALM.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey mapred/hadoop-master-2@OTHERREALM.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey yarn/hadoop-master-2@OTHERREALM.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/hadoop-master-2@OTHERREALM.COM"
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hdfs/hadoop-2@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey mapred/hadoop-2@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey yarn/hadoop-2@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/hadoop-2@OTHERREALM.COM"
 
 # CREATE HADOOP KEYTAB FILES
-RUN /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/hdfs.keytab hdfs/hadoop-master-2 HTTP/hadoop-master-2" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/mapred.keytab mapred/hadoop-master-2 HTTP/hadoop-master-2" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/yarn.keytab yarn/hadoop-master-2 HTTP/hadoop-master-2" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/HTTP.keytab HTTP/hadoop-master-2"
+RUN /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/hdfs.keytab hdfs/hadoop-2 HTTP/hadoop-2" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/mapred.keytab mapred/hadoop-2 HTTP/hadoop-2" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/yarn.keytab yarn/hadoop-2 HTTP/hadoop-2" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/HTTP.keytab HTTP/hadoop-2"
 RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs.keytab \
   && chown mapred:hadoop /etc/hadoop/conf/mapred.keytab \
   && chown yarn:hadoop /etc/hadoop/conf/yarn.keytab \
@@ -43,8 +43,8 @@ RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs.keytab \
   && chmod 644 /etc/hadoop/conf/*.keytab
 
 # CREATE HIVE PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop-master-2@OTHERREALM.COM" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hive/conf/hive.keytab hive/hadoop-master-2"
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop-2@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hive/conf/hive.keytab hive/hadoop-2"
 RUN chown hive:hadoop /etc/hive/conf/hive.keytab \
   && chmod 644 /etc/hive/conf/hive.keytab
 
@@ -78,8 +78,8 @@ RUN chmod 644 /etc/trino/conf/keystore.jks
 RUN set -xeu; \
     for user in root hive hdfs; do \
         sudo -u "${user}" bash -c ' echo "klist -kt /etc/hive/conf/hive.keytab" >> ~/.bash_history '; \
-        sudo -u "${user}" bash -c ' echo "kinit -kt /etc/hive/conf/hive.keytab hive/hadoop-master-2@OTHERREALM.COM" >> ~/.bash_history '; \
-        sudo -u "${user}" bash -c ' echo "beeline -u \"jdbc:hive2://hadoop-master-2:10000/default;principal=hive/hadoop-master-2@OTHERREALM.COM\"" >> ~/.bash_history '; \
+        sudo -u "${user}" bash -c ' echo "kinit -kt /etc/hive/conf/hive.keytab hive/hadoop-2@OTHERREALM.COM" >> ~/.bash_history '; \
+        sudo -u "${user}" bash -c ' echo "beeline -u \"jdbc:hive2://hadoop-2:10000/default;principal=hive/hadoop-2@OTHERREALM.COM\"" >> ~/.bash_history '; \
     done
 
 # EXPOSE KERBEROS PORTS

--- a/testing/hdp2.6-hive-kerberized-2/Dockerfile
+++ b/testing/hdp2.6-hive-kerberized-2/Dockerfile
@@ -49,18 +49,18 @@ RUN chown hive:hadoop /etc/hive/conf/hive.keytab \
   && chmod 644 /etc/hive/conf/hive.keytab
 
 # CREATE TRINO PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-master.docker.cluster@OTHERREALM.COM" \
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-coordinator.docker.cluster@OTHERREALM.COM" \
   && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker.docker.cluster@OTHERREALM.COM" \
   && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-1.docker.cluster@OTHERREALM.COM" \
   && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-2.docker.cluster@OTHERREALM.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-master.docker.cluster@OTHERREALM.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-master.docker.cluster@OTHERREALM.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-master.docker.cluster@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-coordinator.docker.cluster@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-coordinator.docker.cluster@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-coordinator.docker.cluster@OTHERREALM.COM" \
   && mkdir -p /etc/trino/conf \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server.keytab trino-server/trino-master.docker.cluster trino-server/trino-worker.docker.cluster trino-server/trino-worker-1.docker.cluster trino-server/trino-worker-2.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server-HTTP.keytab HTTP/trino-master.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-client.keytab trino-client/trino-master.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/hive-trino-master.keytab hive/trino-master.docker.cluster"
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server.keytab trino-server/trino-coordinator.docker.cluster trino-server/trino-worker.docker.cluster trino-server/trino-worker-1.docker.cluster trino-server/trino-worker-2.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server-HTTP.keytab HTTP/trino-coordinator.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-client.keytab trino-client/trino-coordinator.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/hive-trino-coordinator.keytab hive/trino-coordinator.docker.cluster"
 RUN chmod 644 /etc/trino/conf/*.keytab
 
 # CREATE SSL KEYSTORE
@@ -70,7 +70,7 @@ RUN keytool -genkeypair \
     -keystore /etc/trino/conf/keystore.jks \
     -keypass password \
     -storepass password \
-    -dname "CN=trino-master, OU=, O=, L=, S=, C=" \
+    -dname "CN=trino-coordinator, OU=, O=, L=, S=, C=" \
     -validity 100000
 RUN chmod 644 /etc/trino/conf/keystore.jks
 

--- a/testing/hdp2.6-hive-kerberized-2/Dockerfile
+++ b/testing/hdp2.6-hive-kerberized-2/Dockerfile
@@ -10,8 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use last layer from ghcr.io/trinodb/testing/hdp3.1-hive:38
-FROM f387ea8b4011
+FROM testing/hdp2.6-hive:unlabelled
+
+# INSTALL KERBEROS
+RUN yum install -y krb5-libs krb5-server krb5-workstation \
+  && yum -y clean all && rm -rf /tmp/* /var/tmp/*
 
 # COPY CONFIGURATION
 COPY ./files /
@@ -19,8 +22,7 @@ COPY ./files /
 # Apply configuration overrides
 RUN /usr/local/bin/apply-all-site-xml-overrides /overrides
 
-# (RE)CREATE KERBEROS DATABASE
-RUN rm -rf /var/kerberos/krb5kdc/principal*
+# CREATE KERBEROS DATABASE
 RUN /usr/sbin/kdb5_util create -s -P password
 
 # ADD HADOOP PRINCIPALS

--- a/testing/hdp2.6-hive-kerberized-2/Dockerfile
+++ b/testing/hdp2.6-hive-kerberized-2/Dockerfile
@@ -70,7 +70,7 @@ RUN keytool -genkeypair \
     -keystore /etc/trino/conf/keystore.jks \
     -keypass password \
     -storepass password \
-    -dname "CN=trino-coordinator, OU=, O=, L=, S=, C=" \
+    -dname "OU=, O=, L=, S=, C=" \
     -validity 100000
 RUN chmod 644 /etc/trino/conf/keystore.jks
 

--- a/testing/hdp2.6-hive-kerberized-2/Dockerfile
+++ b/testing/hdp2.6-hive-kerberized-2/Dockerfile
@@ -48,19 +48,19 @@ RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop-master-2@OTHERREALM
 RUN chown hive:hadoop /etc/hive/conf/hive.keytab \
   && chmod 644 /etc/hive/conf/hive.keytab
 
-# CREATE PRESTO PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-master.docker.cluster@OTHERREALM.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker.docker.cluster@OTHERREALM.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker-1.docker.cluster@OTHERREALM.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker-2.docker.cluster@OTHERREALM.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/presto-master.docker.cluster@OTHERREALM.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-client/presto-master.docker.cluster@OTHERREALM.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/presto-master.docker.cluster@OTHERREALM.COM" \
+# CREATE TRINO PRINCIPAL AND KEYTAB
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-master.docker.cluster@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker.docker.cluster@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-1.docker.cluster@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-2.docker.cluster@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-master.docker.cluster@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-master.docker.cluster@OTHERREALM.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-master.docker.cluster@OTHERREALM.COM" \
   && mkdir -p /etc/trino/conf \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/presto-server.keytab presto-server/presto-master.docker.cluster presto-server/presto-worker.docker.cluster presto-server/presto-worker-1.docker.cluster presto-server/presto-worker-2.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/presto-server-HTTP.keytab HTTP/presto-master.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/presto-client.keytab presto-client/presto-master.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/hive-presto-master.keytab hive/presto-master.docker.cluster"
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server.keytab trino-server/trino-master.docker.cluster trino-server/trino-worker.docker.cluster trino-server/trino-worker-1.docker.cluster trino-server/trino-worker-2.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server-HTTP.keytab HTTP/trino-master.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-client.keytab trino-client/trino-master.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/hive-trino-master.keytab hive/trino-master.docker.cluster"
 RUN chmod 644 /etc/trino/conf/*.keytab
 
 # CREATE SSL KEYSTORE
@@ -70,7 +70,7 @@ RUN keytool -genkeypair \
     -keystore /etc/trino/conf/keystore.jks \
     -keypass password \
     -storepass password \
-    -dname "CN=presto-master, OU=, O=, L=, S=, C=" \
+    -dname "CN=trino-master, OU=, O=, L=, S=, C=" \
     -validity 100000
 RUN chmod 644 /etc/trino/conf/keystore.jks
 

--- a/testing/hdp2.6-hive-kerberized-2/Dockerfile
+++ b/testing/hdp2.6-hive-kerberized-2/Dockerfile
@@ -10,11 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM testing/hdp2.6-hive:unlabelled
-
-# INSTALL KERBEROS
-RUN yum install -y krb5-libs krb5-server krb5-workstation \
-  && yum -y clean all && rm -rf /tmp/* /var/tmp/*
+# Use last layer from ghcr.io/trinodb/testing/hdp3.1-hive:38
+FROM f387ea8b4011
 
 # COPY CONFIGURATION
 COPY ./files /
@@ -22,7 +19,8 @@ COPY ./files /
 # Apply configuration overrides
 RUN /usr/local/bin/apply-all-site-xml-overrides /overrides
 
-# CREATE KERBEROS DATABASE
+# (RE)CREATE KERBEROS DATABASE
+RUN rm -rf /var/kerberos/krb5kdc/principal*
 RUN /usr/sbin/kdb5_util create -s -P password
 
 # ADD HADOOP PRINCIPALS

--- a/testing/hdp2.6-hive-kerberized-2/files/etc/krb5.conf
+++ b/testing/hdp2.6-hive-kerberized-2/files/etc/krb5.conf
@@ -11,6 +11,6 @@
 
 [realms]
  OTHERREALM.COM = {
-  kdc = hadoop-master-2:88
-  admin_server = hadoop-master-2
+  kdc = hadoop-2:88
+  admin_server = hadoop-2
  }

--- a/testing/hdp2.6-hive-kerberized-2/files/overrides/etc/hadoop/conf/core-site.xml
+++ b/testing/hdp2.6-hive-kerberized-2/files/overrides/etc/hadoop/conf/core-site.xml
@@ -19,7 +19,7 @@
 
     <property>
         <name>fs.defaultFS</name>
-        <value>hdfs://hadoop-master-2:9000</value>
+        <value>hdfs://hadoop-2:9000</value>
     </property>
 
     <!-- Trino impersonation -->

--- a/testing/hdp2.6-hive-kerberized-2/files/overrides/etc/hadoop/conf/hdfs-site.xml
+++ b/testing/hdp2.6-hive-kerberized-2/files/overrides/etc/hadoop/conf/hdfs-site.xml
@@ -28,11 +28,11 @@
     </property>
     <property>
         <name>dfs.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master-2@OTHERREALM.COM</value>
+        <value>hdfs/hadoop-2@OTHERREALM.COM</value>
     </property>
     <property>
         <name>dfs.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master-2@OTHERREALM.COM</value>
+        <value>HTTP/hadoop-2@OTHERREALM.COM</value>
     </property>
 
     <!-- Secondary NameNode security config -->
@@ -42,11 +42,11 @@
     </property>
     <property>
         <name>dfs.secondary.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master-2@OTHERREALM.COM</value>
+        <value>hdfs/hadoop-2@OTHERREALM.COM</value>
     </property>
     <property>
         <name>dfs.secondary.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master-2@OTHERREALM.COM</value>
+        <value>HTTP/hadoop-2@OTHERREALM.COM</value>
     </property>
 
     <!-- DataNode security config -->
@@ -56,7 +56,7 @@
     </property>
     <property>
         <name>dfs.datanode.kerberos.principal</name>
-        <value>hdfs/hadoop-master-2@OTHERREALM.COM</value>
+        <value>hdfs/hadoop-2@OTHERREALM.COM</value>
     </property>
 
     <!-- WebHDFS security config -->
@@ -68,7 +68,7 @@
     <!-- Web Authentication config -->
     <property>
         <name>dfs.web.authentication.kerberos.principal</name>
-        <value>HTTP/hadoop-master-2@OTHERREALM.COM</value>
+        <value>HTTP/hadoop-2@OTHERREALM.COM</value>
     </property>
 
     <property>

--- a/testing/hdp2.6-hive-kerberized-2/files/overrides/etc/hadoop/conf/mapred-site.xml
+++ b/testing/hdp2.6-hive-kerberized-2/files/overrides/etc/hadoop/conf/mapred-site.xml
@@ -19,17 +19,17 @@
 
     <property>
         <name>mapred.job.tracker</name>
-        <value>hadoop-master-2:8021</value>
+        <value>hadoop-2:8021</value>
     </property>
 
     <property>
         <name>mapreduce.jobhistory.address</name>
-        <value>hadoop-master-2:10020</value>
+        <value>hadoop-2:10020</value>
     </property>
 
     <property>
         <name>mapreduce.jobhistory.webapp.address</name>
-        <value>hadoop-master-2:19888</value>
+        <value>hadoop-2:19888</value>
     </property>
 
     <!-- MapReduce Job History Server security configs -->
@@ -40,13 +40,13 @@
 
     <property>
         <name>mapreduce.jobhistory.principal</name>
-        <value>mapred/hadoop-master-2@OTHERREALM.COM</value>
+        <value>mapred/hadoop-2@OTHERREALM.COM</value>
     </property>
 
     <!-- JobTracker security configs -->
     <property>
         <name>mapreduce.jobtracker.kerberos.principal</name>
-        <value>mapred/hadoop-master-2@OTHERREALM.COM</value>
+        <value>mapred/hadoop-2@OTHERREALM.COM</value>
     </property>
 
     <property>
@@ -57,7 +57,7 @@
     <!-- TaskTracker security configs -->
     <property>
         <name>mapreduce.tasktracker.kerberos.principal</name>
-        <value>mapred/hadoop-master-2@OTHERREALM.COM</value>
+        <value>mapred/hadoop-2@OTHERREALM.COM</value>
     </property>
 
     <property>

--- a/testing/hdp2.6-hive-kerberized-2/files/overrides/etc/hadoop/conf/yarn-site.xml
+++ b/testing/hdp2.6-hive-kerberized-2/files/overrides/etc/hadoop/conf/yarn-site.xml
@@ -20,12 +20,12 @@
 
     <property>
         <name>yarn.resourcemanager.hostname</name>
-        <value>hadoop-master-2</value>
+        <value>hadoop-2</value>
     </property>
 
     <property>
         <name>yarn.log.server.url</name>
-        <value>http://hadoop-master-2:19888/jobhistory/logs</value>
+        <value>http://hadoop-2:19888/jobhistory/logs</value>
     </property>
 
     <!-- ResourceManager security configs -->
@@ -36,7 +36,7 @@
 
     <property>
         <name>yarn.resourcemanager.principal</name>
-        <value>yarn/hadoop-master-2@OTHERREALM.COM</value>
+        <value>yarn/hadoop-2@OTHERREALM.COM</value>
     </property>
 
     <!-- NodeManager security configs -->
@@ -47,7 +47,7 @@
 
     <property>
         <name>yarn.nodemanager.principal</name>
-        <value>yarn/hadoop-master-2@OTHERREALM.COM</value>
+        <value>yarn/hadoop-2@OTHERREALM.COM</value>
     </property>
 
 </configuration>

--- a/testing/hdp2.6-hive-kerberized-2/files/overrides/etc/hive/conf/hive-site.xml
+++ b/testing/hdp2.6-hive-kerberized-2/files/overrides/etc/hive/conf/hive-site.xml
@@ -30,7 +30,7 @@
 
     <property>
         <name>hive.server2.authentication.kerberos.principal</name>
-        <value>hive/hadoop-master-2@OTHERREALM.COM</value>
+        <value>hive/hadoop-2@OTHERREALM.COM</value>
     </property>
 
     <property>
@@ -50,7 +50,7 @@
 
     <property>
         <name>hive.metastore.kerberos.principal</name>
-        <value>hive/hadoop-master-2@OTHERREALM.COM</value>
+        <value>hive/hadoop-2@OTHERREALM.COM</value>
     </property>
 
     <!-- Enable SQL based authorization -->

--- a/testing/hdp2.6-hive-kerberized/Dockerfile
+++ b/testing/hdp2.6-hive-kerberized/Dockerfile
@@ -10,11 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM testing/hdp2.6-hive:unlabelled
-
-# INSTALL KERBEROS
-RUN yum install -y krb5-libs krb5-server krb5-workstation \
-  && yum -y clean all && rm -rf /tmp/* /var/tmp/*
+# Use last layer from ghcr.io/trinodb/testing/hdp3.1-hive-kerberized:38
+FROM f387ea8b4011
 
 # COPY CONFIGURATION
 COPY ./files /
@@ -22,7 +19,8 @@ COPY ./files /
 # Apply configuration overrides
 RUN /usr/local/bin/apply-all-site-xml-overrides /overrides
 
-# CREATE KERBEROS DATABASE
+# (RE)CREATE KERBEROS DATABASE
+RUN rm -rf /var/kerberos/krb5kdc/principal*
 RUN /usr/sbin/kdb5_util create -s -P password
 
 # CREATE ANOTHER KERBEROS DATABASE

--- a/testing/hdp2.6-hive-kerberized/Dockerfile
+++ b/testing/hdp2.6-hive-kerberized/Dockerfile
@@ -68,18 +68,18 @@ RUN /usr/sbin/kadmin.local -q "addprinc -pw 123456 krbtgt/LABS.TERADATA.COM@OTHE
 RUN /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "addprinc -pw 123456 krbtgt/LABS.TERADATA.COM"
 
 # CREATE TRINO PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-master.docker.cluster@LABS.TERADATA.COM" \
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
   && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker.docker.cluster@LABS.TERADATA.COM" \
   && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-1.docker.cluster@LABS.TERADATA.COM" \
   && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-2.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-master.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
   && mkdir -p /etc/trino/conf \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server.keytab trino-server/trino-master.docker.cluster trino-server/trino-worker.docker.cluster trino-server/trino-worker-1.docker.cluster trino-server/trino-worker-2.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server-HTTP.keytab HTTP/trino-master.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-client.keytab trino-client/trino-master.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/hive-trino-master.keytab hive/trino-master.docker.cluster"
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server.keytab trino-server/trino-coordinator.docker.cluster trino-server/trino-worker.docker.cluster trino-server/trino-worker-1.docker.cluster trino-server/trino-worker-2.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server-HTTP.keytab HTTP/trino-coordinator.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-client.keytab trino-client/trino-coordinator.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/hive-trino-coordinator.keytab hive/trino-coordinator.docker.cluster"
 RUN chmod 644 /etc/trino/conf/*.keytab
 
 # CREATE SSL KEYSTORE
@@ -89,7 +89,7 @@ RUN keytool -genkeypair \
     -keystore /etc/trino/conf/keystore.jks \
     -keypass password \
     -storepass password \
-    -dname "CN=trino-master, OU=, O=, L=, S=, C=" \
+    -dname "CN=trino-coordinator, OU=, O=, L=, S=, C=" \
     -validity 100000
 RUN chmod 644 /etc/trino/conf/keystore.jks
 

--- a/testing/hdp2.6-hive-kerberized/Dockerfile
+++ b/testing/hdp2.6-hive-kerberized/Dockerfile
@@ -29,16 +29,16 @@ RUN /usr/sbin/kdb5_util create -s -P password
 RUN /usr/sbin/kdb5_util create -d /var/kerberos/krb5kdc/principal-other -r OTHERLABS.TRINO.IO -s -P password
 
 # ADD HADOOP PRINCIPALS
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey hdfs/hadoop-master@LABS.TRINO.IO" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey mapred/hadoop-master@LABS.TRINO.IO" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey yarn/hadoop-master@LABS.TRINO.IO" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/hadoop-master@LABS.TRINO.IO"
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hdfs/hadoop@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey mapred/hadoop@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey yarn/hadoop@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/hadoop@LABS.TRINO.IO"
 
 # CREATE HADOOP KEYTAB FILES
-RUN /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/hdfs.keytab hdfs/hadoop-master HTTP/hadoop-master" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/mapred.keytab mapred/hadoop-master HTTP/hadoop-master" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/yarn.keytab yarn/hadoop-master HTTP/hadoop-master" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/HTTP.keytab HTTP/hadoop-master"
+RUN /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/hdfs.keytab hdfs/hadoop HTTP/hadoop" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/mapred.keytab mapred/hadoop HTTP/hadoop" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/yarn.keytab yarn/hadoop HTTP/hadoop" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/HTTP.keytab HTTP/hadoop"
 RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs.keytab \
   && chown mapred:hadoop /etc/hadoop/conf/mapred.keytab \
   && chown yarn:hadoop /etc/hadoop/conf/yarn.keytab \
@@ -46,20 +46,20 @@ RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs.keytab \
   && chmod 644 /etc/hadoop/conf/*.keytab
 
 # CREATE HIVE PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop-master@LABS.TRINO.IO" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hive/conf/hive.keytab hive/hadoop-master"
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hive/conf/hive.keytab hive/hadoop"
 RUN chown hive:hadoop /etc/hive/conf/hive.keytab \
   && chmod 644 /etc/hive/conf/hive.keytab
 
 # CREATE HIVE PRINCIPAL IN THE OTHER REALM
-RUN /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "addprinc -randkey hive/hadoop-master@OTHERLABS.TRINO.IO" \
-  && /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "xst -norandkey -k /etc/hive/conf/hive-other.keytab hive/hadoop-master"
+RUN /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "addprinc -randkey hive/hadoop@OTHERLABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "xst -norandkey -k /etc/hive/conf/hive-other.keytab hive/hadoop"
 RUN chown hive:hadoop /etc/hive/conf/hive-other.keytab \
   && chmod 644 /etc/hive/conf/hive-other.keytab
 
 # CREATE HDFS PRINCIPAL IN OTHER REALM
-RUN /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "addprinc -randkey hdfs/hadoop-master@OTHERLABS.TRINO.IO" \
-  && /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "xst -norandkey -k /etc/hadoop/conf/hdfs-other.keytab hdfs/hadoop-master"
+RUN /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "addprinc -randkey hdfs/hadoop@OTHERLABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "xst -norandkey -k /etc/hadoop/conf/hdfs-other.keytab hdfs/hadoop"
 RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs-other.keytab \
   && chmod 644 /etc/hadoop/conf/hdfs-other.keytab
 
@@ -97,8 +97,8 @@ RUN chmod 644 /etc/trino/conf/keystore.jks
 RUN set -xeu; \
     for user in root hive hdfs; do \
         sudo -u "${user}" bash -c ' echo "klist -kt /etc/hive/conf/hive.keytab" >> ~/.bash_history '; \
-        sudo -u "${user}" bash -c ' echo "kinit -kt /etc/hive/conf/hive.keytab hive/hadoop-master@LABS.TRINO.IO" >> ~/.bash_history '; \
-        sudo -u "${user}" bash -c ' echo "beeline -u \"jdbc:hive2://hadoop-master:10000/default;principal=hive/hadoop-master@LABS.TRINO.IO\"" >> ~/.bash_history '; \
+        sudo -u "${user}" bash -c ' echo "kinit -kt /etc/hive/conf/hive.keytab hive/hadoop@LABS.TRINO.IO" >> ~/.bash_history '; \
+        sudo -u "${user}" bash -c ' echo "beeline -u \"jdbc:hive2://hadoop:10000/default;principal=hive/hadoop@LABS.TRINO.IO\"" >> ~/.bash_history '; \
     done
 
 # EXPOSE KERBEROS PORTS

--- a/testing/hdp2.6-hive-kerberized/Dockerfile
+++ b/testing/hdp2.6-hive-kerberized/Dockerfile
@@ -89,7 +89,7 @@ RUN keytool -genkeypair \
     -keystore /etc/trino/conf/keystore.jks \
     -keypass password \
     -storepass password \
-    -dname "CN=trino-coordinator, OU=, O=, L=, S=, C=" \
+    -dname "OU=, O=, L=, S=, C=" \
     -validity 100000
 RUN chmod 644 /etc/trino/conf/keystore.jks
 

--- a/testing/hdp2.6-hive-kerberized/Dockerfile
+++ b/testing/hdp2.6-hive-kerberized/Dockerfile
@@ -10,8 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use last layer from ghcr.io/trinodb/testing/hdp3.1-hive-kerberized:38
-FROM f387ea8b4011
+FROM testing/hdp2.6-hive:unlabelled
+
+# INSTALL KERBEROS
+RUN yum install -y krb5-libs krb5-server krb5-workstation \
+  && yum -y clean all && rm -rf /tmp/* /var/tmp/*
 
 # COPY CONFIGURATION
 COPY ./files /
@@ -19,8 +22,7 @@ COPY ./files /
 # Apply configuration overrides
 RUN /usr/local/bin/apply-all-site-xml-overrides /overrides
 
-# (RE)CREATE KERBEROS DATABASE
-RUN rm -rf /var/kerberos/krb5kdc/principal*
+# CREATE KERBEROS DATABASE
 RUN /usr/sbin/kdb5_util create -s -P password
 
 # CREATE ANOTHER KERBEROS DATABASE

--- a/testing/hdp2.6-hive-kerberized/Dockerfile
+++ b/testing/hdp2.6-hive-kerberized/Dockerfile
@@ -26,13 +26,13 @@ RUN /usr/local/bin/apply-all-site-xml-overrides /overrides
 RUN /usr/sbin/kdb5_util create -s -P password
 
 # CREATE ANOTHER KERBEROS DATABASE
-RUN /usr/sbin/kdb5_util create -d /var/kerberos/krb5kdc/principal-other -r OTHERLABS.TERADATA.COM -s -P password
+RUN /usr/sbin/kdb5_util create -d /var/kerberos/krb5kdc/principal-other -r OTHERLABS.TRINO.IO -s -P password
 
 # ADD HADOOP PRINCIPALS
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey hdfs/hadoop-master@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey mapred/hadoop-master@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey yarn/hadoop-master@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/hadoop-master@LABS.TERADATA.COM"
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hdfs/hadoop-master@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey mapred/hadoop-master@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey yarn/hadoop-master@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/hadoop-master@LABS.TRINO.IO"
 
 # CREATE HADOOP KEYTAB FILES
 RUN /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/hdfs.keytab hdfs/hadoop-master HTTP/hadoop-master" \
@@ -46,35 +46,35 @@ RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs.keytab \
   && chmod 644 /etc/hadoop/conf/*.keytab
 
 # CREATE HIVE PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop-master@LABS.TERADATA.COM" \
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop-master@LABS.TRINO.IO" \
   && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hive/conf/hive.keytab hive/hadoop-master"
 RUN chown hive:hadoop /etc/hive/conf/hive.keytab \
   && chmod 644 /etc/hive/conf/hive.keytab
 
 # CREATE HIVE PRINCIPAL IN THE OTHER REALM
-RUN /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "addprinc -randkey hive/hadoop-master@OTHERLABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "xst -norandkey -k /etc/hive/conf/hive-other.keytab hive/hadoop-master"
+RUN /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "addprinc -randkey hive/hadoop-master@OTHERLABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "xst -norandkey -k /etc/hive/conf/hive-other.keytab hive/hadoop-master"
 RUN chown hive:hadoop /etc/hive/conf/hive-other.keytab \
   && chmod 644 /etc/hive/conf/hive-other.keytab
 
 # CREATE HDFS PRINCIPAL IN OTHER REALM
-RUN /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "addprinc -randkey hdfs/hadoop-master@OTHERLABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "xst -norandkey -k /etc/hadoop/conf/hdfs-other.keytab hdfs/hadoop-master"
+RUN /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "addprinc -randkey hdfs/hadoop-master@OTHERLABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "xst -norandkey -k /etc/hadoop/conf/hdfs-other.keytab hdfs/hadoop-master"
 RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs-other.keytab \
   && chmod 644 /etc/hadoop/conf/hdfs-other.keytab
 
-# MAKE 'LABS.TERADATA.COM' TRUST 'OTHERLABS.TERADATA.COM'
-RUN /usr/sbin/kadmin.local -q "addprinc -pw 123456 krbtgt/LABS.TERADATA.COM@OTHERLABS.TERADATA.COM"
-RUN /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "addprinc -pw 123456 krbtgt/LABS.TERADATA.COM"
+# MAKE 'LABS.TRINO.IO' TRUST 'OTHERLABS.TRINO.IO'
+RUN /usr/sbin/kadmin.local -q "addprinc -pw 123456 krbtgt/LABS.TRINO.IO@OTHERLABS.TRINO.IO"
+RUN /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "addprinc -pw 123456 krbtgt/LABS.TRINO.IO"
 
 # CREATE TRINO PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-1.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-2.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-coordinator.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-1.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-2.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-coordinator.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-coordinator.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-coordinator.docker.cluster@LABS.TRINO.IO" \
   && mkdir -p /etc/trino/conf \
   && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server.keytab trino-server/trino-coordinator.docker.cluster trino-server/trino-worker.docker.cluster trino-server/trino-worker-1.docker.cluster trino-server/trino-worker-2.docker.cluster" \
   && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server-HTTP.keytab HTTP/trino-coordinator.docker.cluster" \
@@ -97,8 +97,8 @@ RUN chmod 644 /etc/trino/conf/keystore.jks
 RUN set -xeu; \
     for user in root hive hdfs; do \
         sudo -u "${user}" bash -c ' echo "klist -kt /etc/hive/conf/hive.keytab" >> ~/.bash_history '; \
-        sudo -u "${user}" bash -c ' echo "kinit -kt /etc/hive/conf/hive.keytab hive/hadoop-master@LABS.TERADATA.COM" >> ~/.bash_history '; \
-        sudo -u "${user}" bash -c ' echo "beeline -u \"jdbc:hive2://hadoop-master:10000/default;principal=hive/hadoop-master@LABS.TERADATA.COM\"" >> ~/.bash_history '; \
+        sudo -u "${user}" bash -c ' echo "kinit -kt /etc/hive/conf/hive.keytab hive/hadoop-master@LABS.TRINO.IO" >> ~/.bash_history '; \
+        sudo -u "${user}" bash -c ' echo "beeline -u \"jdbc:hive2://hadoop-master:10000/default;principal=hive/hadoop-master@LABS.TRINO.IO\"" >> ~/.bash_history '; \
     done
 
 # EXPOSE KERBEROS PORTS

--- a/testing/hdp2.6-hive-kerberized/Dockerfile
+++ b/testing/hdp2.6-hive-kerberized/Dockerfile
@@ -67,29 +67,29 @@ RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs-other.keytab \
 RUN /usr/sbin/kadmin.local -q "addprinc -pw 123456 krbtgt/LABS.TERADATA.COM@OTHERLABS.TERADATA.COM"
 RUN /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "addprinc -pw 123456 krbtgt/LABS.TERADATA.COM"
 
-# CREATE PRESTO PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker-1.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker-2.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/presto-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-client/presto-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/presto-master.docker.cluster@LABS.TERADATA.COM" \
+# CREATE TRINO PRINCIPAL AND KEYTAB
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-master.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-1.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-2.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-master.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-master.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-master.docker.cluster@LABS.TERADATA.COM" \
   && mkdir -p /etc/trino/conf \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/presto-server.keytab presto-server/presto-master.docker.cluster presto-server/presto-worker.docker.cluster presto-server/presto-worker-1.docker.cluster presto-server/presto-worker-2.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/presto-server-HTTP.keytab HTTP/presto-master.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/presto-client.keytab presto-client/presto-master.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/hive-presto-master.keytab hive/presto-master.docker.cluster"
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server.keytab trino-server/trino-master.docker.cluster trino-server/trino-worker.docker.cluster trino-server/trino-worker-1.docker.cluster trino-server/trino-worker-2.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server-HTTP.keytab HTTP/trino-master.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-client.keytab trino-client/trino-master.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/hive-trino-master.keytab hive/trino-master.docker.cluster"
 RUN chmod 644 /etc/trino/conf/*.keytab
 
 # CREATE SSL KEYSTORE
 RUN keytool -genkeypair \
-    -alias presto \
+    -alias trino \
     -keyalg RSA \
     -keystore /etc/trino/conf/keystore.jks \
     -keypass password \
     -storepass password \
-    -dname "CN=presto-master, OU=, O=, L=, S=, C=" \
+    -dname "CN=trino-master, OU=, O=, L=, S=, C=" \
     -validity 100000
 RUN chmod 644 /etc/trino/conf/keystore.jks
 

--- a/testing/hdp2.6-hive-kerberized/files/etc/krb5.conf
+++ b/testing/hdp2.6-hive-kerberized/files/etc/krb5.conf
@@ -11,10 +11,10 @@
 
 [realms]
  LABS.TRINO.IO = {
-  kdc = hadoop-master:88
-  admin_server = hadoop-master
+  kdc = hadoop:88
+  admin_server = hadoop
  }
  OTHERLABS.TRINO.IO = {
-  kdc = hadoop-master:89
-  admin_server = hadoop-master
+  kdc = hadoop:89
+  admin_server = hadoop
  }

--- a/testing/hdp2.6-hive-kerberized/files/etc/krb5.conf
+++ b/testing/hdp2.6-hive-kerberized/files/etc/krb5.conf
@@ -4,17 +4,17 @@
  admin_server = FILE:/var/log/kadmind.log
 
 [libdefaults]
- default_realm = LABS.TERADATA.COM
+ default_realm = LABS.TRINO.IO
  dns_lookup_realm = false
  dns_lookup_kdc = false
  forwardable = true
 
 [realms]
- LABS.TERADATA.COM = {
+ LABS.TRINO.IO = {
   kdc = hadoop-master:88
   admin_server = hadoop-master
  }
- OTHERLABS.TERADATA.COM = {
+ OTHERLABS.TRINO.IO = {
   kdc = hadoop-master:89
   admin_server = hadoop-master
  }

--- a/testing/hdp2.6-hive-kerberized/files/etc/supervisord.d/kdc.conf
+++ b/testing/hdp2.6-hive-kerberized/files/etc/supervisord.d/kdc.conf
@@ -1,5 +1,5 @@
 [program:krb5kdc]
-command=/bin/bash -c "exec /usr/sbin/krb5kdc -P /var/run/krb5kdc.pid -n -r LABS.TERADATA.COM -n -d /var/kerberos/krb5kdc/principal-other -r OTHERLABS.TERADATA.COM"
+command=/bin/bash -c "exec /usr/sbin/krb5kdc -P /var/run/krb5kdc.pid -n -r LABS.TRINO.IO -n -d /var/kerberos/krb5kdc/principal-other -r OTHERLABS.TRINO.IO"
 autostart=true
 autorestart=true
 redirect_stderr=true
@@ -7,7 +7,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:kadmind]
-command=/bin/bash -c "exec /usr/sbin/kadmind -P /var/run/kadmind.pid -nofork -r LABS.TERADATA.COM"
+command=/bin/bash -c "exec /usr/sbin/kadmind -P /var/run/kadmind.pid -nofork -r LABS.TRINO.IO"
 autostart=true
 autorestart=true
 redirect_stderr=true

--- a/testing/hdp2.6-hive-kerberized/files/overrides/etc/hadoop/conf/core-site.xml
+++ b/testing/hdp2.6-hive-kerberized/files/overrides/etc/hadoop/conf/core-site.xml
@@ -42,7 +42,7 @@
     <property>
         <name>hadoop.security.auth_to_local</name>
         <value>
-            RULE:[2:$1@$0](.*@OTHERLABS.TERADATA.COM)s/@.*//
+            RULE:[2:$1@$0](.*@OTHERLABS.TRINO.IO)s/@.*//
             DEFAULT
         </value>
     </property>

--- a/testing/hdp2.6-hive-kerberized/files/overrides/etc/hadoop/conf/hdfs-site.xml
+++ b/testing/hdp2.6-hive-kerberized/files/overrides/etc/hadoop/conf/hdfs-site.xml
@@ -28,11 +28,11 @@
     </property>
     <property>
         <name>dfs.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
     </property>
     <property>
         <name>dfs.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master@LABS.TERADATA.COM</value>
+        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- Secondary NameNode security config -->
@@ -42,11 +42,11 @@
     </property>
     <property>
         <name>dfs.secondary.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
     </property>
     <property>
         <name>dfs.secondary.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master@LABS.TERADATA.COM</value>
+        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- DataNode security config -->
@@ -56,7 +56,7 @@
     </property>
     <property>
         <name>dfs.datanode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- WebHDFS security config -->
@@ -68,7 +68,7 @@
     <!-- Web Authentication config -->
     <property>
         <name>dfs.web.authentication.kerberos.principal</name>
-        <value>HTTP/hadoop-master@LABS.TERADATA.COM</value>
+        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>

--- a/testing/hdp2.6-hive-kerberized/files/overrides/etc/hadoop/conf/hdfs-site.xml
+++ b/testing/hdp2.6-hive-kerberized/files/overrides/etc/hadoop/conf/hdfs-site.xml
@@ -28,11 +28,11 @@
     </property>
     <property>
         <name>dfs.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
+        <value>hdfs/hadoop@LABS.TRINO.IO</value>
     </property>
     <property>
         <name>dfs.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
+        <value>HTTP/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- Secondary NameNode security config -->
@@ -42,11 +42,11 @@
     </property>
     <property>
         <name>dfs.secondary.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
+        <value>hdfs/hadoop@LABS.TRINO.IO</value>
     </property>
     <property>
         <name>dfs.secondary.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
+        <value>HTTP/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- DataNode security config -->
@@ -56,7 +56,7 @@
     </property>
     <property>
         <name>dfs.datanode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
+        <value>hdfs/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- WebHDFS security config -->
@@ -68,7 +68,7 @@
     <!-- Web Authentication config -->
     <property>
         <name>dfs.web.authentication.kerberos.principal</name>
-        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
+        <value>HTTP/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>

--- a/testing/hdp2.6-hive-kerberized/files/overrides/etc/hadoop/conf/mapred-site.xml
+++ b/testing/hdp2.6-hive-kerberized/files/overrides/etc/hadoop/conf/mapred-site.xml
@@ -25,13 +25,13 @@
 
     <property>
         <name>mapreduce.jobhistory.principal</name>
-        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
+        <value>mapred/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- JobTracker security configs -->
     <property>
         <name>mapreduce.jobtracker.kerberos.principal</name>
-        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
+        <value>mapred/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>
@@ -42,7 +42,7 @@
     <!-- TaskTracker security configs -->
     <property>
         <name>mapreduce.tasktracker.kerberos.principal</name>
-        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
+        <value>mapred/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>

--- a/testing/hdp2.6-hive-kerberized/files/overrides/etc/hadoop/conf/mapred-site.xml
+++ b/testing/hdp2.6-hive-kerberized/files/overrides/etc/hadoop/conf/mapred-site.xml
@@ -25,13 +25,13 @@
 
     <property>
         <name>mapreduce.jobhistory.principal</name>
-        <value>mapred/hadoop-master@LABS.TERADATA.COM</value>
+        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- JobTracker security configs -->
     <property>
         <name>mapreduce.jobtracker.kerberos.principal</name>
-        <value>mapred/hadoop-master@LABS.TERADATA.COM</value>
+        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>
@@ -42,7 +42,7 @@
     <!-- TaskTracker security configs -->
     <property>
         <name>mapreduce.tasktracker.kerberos.principal</name>
-        <value>mapred/hadoop-master@LABS.TERADATA.COM</value>
+        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>

--- a/testing/hdp2.6-hive-kerberized/files/overrides/etc/hadoop/conf/yarn-site.xml
+++ b/testing/hdp2.6-hive-kerberized/files/overrides/etc/hadoop/conf/yarn-site.xml
@@ -26,7 +26,7 @@
 
     <property>
         <name>yarn.resourcemanager.principal</name>
-        <value>yarn/hadoop-master@LABS.TERADATA.COM</value>
+        <value>yarn/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- NodeManager security configs -->
@@ -37,7 +37,7 @@
 
     <property>
         <name>yarn.nodemanager.principal</name>
-        <value>yarn/hadoop-master@LABS.TERADATA.COM</value>
+        <value>yarn/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
 </configuration>

--- a/testing/hdp2.6-hive-kerberized/files/overrides/etc/hadoop/conf/yarn-site.xml
+++ b/testing/hdp2.6-hive-kerberized/files/overrides/etc/hadoop/conf/yarn-site.xml
@@ -26,7 +26,7 @@
 
     <property>
         <name>yarn.resourcemanager.principal</name>
-        <value>yarn/hadoop-master@LABS.TRINO.IO</value>
+        <value>yarn/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- NodeManager security configs -->
@@ -37,7 +37,7 @@
 
     <property>
         <name>yarn.nodemanager.principal</name>
-        <value>yarn/hadoop-master@LABS.TRINO.IO</value>
+        <value>yarn/hadoop@LABS.TRINO.IO</value>
     </property>
 
 </configuration>

--- a/testing/hdp2.6-hive-kerberized/files/overrides/etc/hive/conf/hive-site.xml
+++ b/testing/hdp2.6-hive-kerberized/files/overrides/etc/hive/conf/hive-site.xml
@@ -30,7 +30,7 @@
 
     <property>
         <name>hive.server2.authentication.kerberos.principal</name>
-        <value>hive/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hive/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>
@@ -50,7 +50,7 @@
 
     <property>
         <name>hive.metastore.kerberos.principal</name>
-        <value>hive/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hive/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- Enable SQL based authorization -->

--- a/testing/hdp2.6-hive-kerberized/files/overrides/etc/hive/conf/hive-site.xml
+++ b/testing/hdp2.6-hive-kerberized/files/overrides/etc/hive/conf/hive-site.xml
@@ -30,7 +30,7 @@
 
     <property>
         <name>hive.server2.authentication.kerberos.principal</name>
-        <value>hive/hadoop-master@LABS.TRINO.IO</value>
+        <value>hive/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>
@@ -50,7 +50,7 @@
 
     <property>
         <name>hive.metastore.kerberos.principal</name>
-        <value>hive/hadoop-master@LABS.TRINO.IO</value>
+        <value>hive/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- Enable SQL based authorization -->

--- a/testing/hdp2.6-hive-kerberized/files/var/kerberos/krb5kdc/kadm5-other.acl
+++ b/testing/hdp2.6-hive-kerberized/files/var/kerberos/krb5kdc/kadm5-other.acl
@@ -1,1 +1,1 @@
-*/admin@OTHERLABS.TERADATA.COM *
+*/admin@OTHERLABS.TRINO.IO *

--- a/testing/hdp2.6-hive-kerberized/files/var/kerberos/krb5kdc/kadm5.acl
+++ b/testing/hdp2.6-hive-kerberized/files/var/kerberos/krb5kdc/kadm5.acl
@@ -1,1 +1,1 @@
-*/admin@LABS.TERADATA.COM	*
+*/admin@LABS.TRINO.IO	*

--- a/testing/hdp2.6-hive-kerberized/files/var/kerberos/krb5kdc/kdc.conf
+++ b/testing/hdp2.6-hive-kerberized/files/var/kerberos/krb5kdc/kdc.conf
@@ -3,14 +3,14 @@
  kdc_tcp_ports = 88
 
 [realms]
- LABS.TERADATA.COM = {
+ LABS.TRINO.IO = {
   acl_file = /var/kerberos/krb5kdc/kadm5.acl
   dict_file = /usr/share/dict/words
   admin_keytab = /var/kerberos/krb5kdc/kadm5.keytab
   supported_enctypes = aes128-cts:normal des3-hmac-sha1:normal arcfour-hmac:normal des-hmac-sha1:normal des-cbc-md5:normal des-cbc-crc:normal
  }
 
- OTHERLABS.TERADATA.COM = {
+ OTHERLABS.TRINO.IO = {
   acl_file = /var/kerberos/krb5kdc/kadm5-other.acl
   dict_file = /usr/share/dict/words
   admin_keytab = /var/kerberos/krb5kdc/kadm5-other.keytab

--- a/testing/hdp2.6-hive/Dockerfile
+++ b/testing/hdp2.6-hive/Dockerfile
@@ -10,16 +10,56 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use last layer from ghcr.io/trinodb/testing/hdp2.6-hive:38
-FROM 6439b9f223a1
+FROM testing/centos6-oj8:unlabelled
+
+# Change default timezone
+RUN ln -snf "/usr/share/zoneinfo/Asia/Kathmandu" /etc/localtime && echo "Asia/Kathmandu" > /etc/timezone
+
+# Install HDP repo
+RUN set -xeu; \
+    wget -nv http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.6.5.0/hdp.repo -P /etc/yum.repos.d; \
+    wget -nv http://public-repo-1.hortonworks.com/HDP-GPL/centos6/2.x/updates/2.6.5.0/hdp.gpl.repo -P /etc/yum.repos.d; \
+    echo OK
+
+# Install Hadoop, Hive (w/ MySQL)
+RUN yum install -y \
+    hadoop-hdfs-namenode \
+    hadoop-hdfs-secondarynamenode \
+    hadoop-hdfs-datanode \
+
+    hadoop-yarn-resourcemanager \
+    hadoop-yarn-nodemanager \
+
+    hive \
+    hive-metastore \
+    hive-server2 \
+
+    hadooplzo \
+    hadooplzo-native \
+    lzo \
+    lzo-devel \
+    lzop \
+
+    mysql-server mysql-connector-java \
+    libxslt \
+
+# Cleanup
+  && yum -y clean all && rm -rf /tmp/* /var/tmp/* \
+  && ln -s /usr/share/java/mysql-connector-java.jar /usr/hdp/current/hive-metastore/lib/mysql-connector-java.jar
+
+# Delete original configuration
+RUN rm -r /etc/hadoop/conf/* \
+  && rm -r /etc/hive/conf/*
 
 # Copy configuration files
 COPY ./files /
 
-# Remove old SSH keys
-RUN rm -Rf /root/.ssh/* /etc/ssh/ssh_host_rsa_key /etc/ssh/ssh_host_dsa_key
+# Run setup script
+RUN /root/setup.sh \
+  && rm -rf /tmp/* /var/tmp/*
 
 # Setup sock proxy
+RUN yum install -y openssh openssh-clients openssh-server && yum -y clean all
 RUN ssh-keygen -t rsa -b 4096 -C "automation@trino.io" -N "" -f /root/.ssh/id_rsa \
   && ssh-keygen -t rsa -b 4096 -N "" -f /etc/ssh/ssh_host_rsa_key \
   && ssh-keygen -t dsa -b 1024 -N "" -f /etc/ssh/ssh_host_dsa_key \
@@ -33,7 +73,6 @@ RUN set -xeu; \
     for user in root hive hdfs; do \
         # ~hive might be owned by root
         chown -R "${user}:" "$(eval echo ~"${user}")"; \
-        sudo -u "${user}" bash -c ' echo "" > ~/.bash_history '; \
         sudo -u "${user}" bash -c ' echo "netstat -ltnp" >> ~/.bash_history '; \
         sudo -u "${user}" bash -c ' echo "beeline -u jdbc:hive2://localhost:10000/default -n hive" >> ~/.bash_history '; \
         sudo -u "${user}" bash -c ' echo "hadoop dfs -ls -R /user/hive/warehouse" >> ~/.bash_history '; \

--- a/testing/hdp2.6-hive/Dockerfile
+++ b/testing/hdp2.6-hive/Dockerfile
@@ -10,56 +10,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM testing/centos6-oj8:unlabelled
-
-# Change default timezone
-RUN ln -snf "/usr/share/zoneinfo/Asia/Kathmandu" /etc/localtime && echo "Asia/Kathmandu" > /etc/timezone
-
-# Install HDP repo
-RUN set -xeu; \
-    wget -nv http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.6.5.0/hdp.repo -P /etc/yum.repos.d; \
-    wget -nv http://public-repo-1.hortonworks.com/HDP-GPL/centos6/2.x/updates/2.6.5.0/hdp.gpl.repo -P /etc/yum.repos.d; \
-    echo OK
-
-# Install Hadoop, Hive (w/ MySQL)
-RUN yum install -y \
-    hadoop-hdfs-namenode \
-    hadoop-hdfs-secondarynamenode \
-    hadoop-hdfs-datanode \
-
-    hadoop-yarn-resourcemanager \
-    hadoop-yarn-nodemanager \
-
-    hive \
-    hive-metastore \
-    hive-server2 \
-
-    hadooplzo \
-    hadooplzo-native \
-    lzo \
-    lzo-devel \
-    lzop \
-
-    mysql-server mysql-connector-java \
-    libxslt \
-
-# Cleanup
-  && yum -y clean all && rm -rf /tmp/* /var/tmp/* \
-  && ln -s /usr/share/java/mysql-connector-java.jar /usr/hdp/current/hive-metastore/lib/mysql-connector-java.jar
-
-# Delete original configuration
-RUN rm -r /etc/hadoop/conf/* \
-  && rm -r /etc/hive/conf/*
+# Use last layer from ghcr.io/trinodb/testing/hdp2.6-hive:38
+FROM 6439b9f223a1
 
 # Copy configuration files
 COPY ./files /
 
-# Run setup script
-RUN /root/setup.sh \
-  && rm -rf /tmp/* /var/tmp/*
+# Remove old SSH keys
+RUN rm -Rf /root/.ssh/* /etc/ssh/ssh_host_rsa_key /etc/ssh/ssh_host_dsa_key
 
 # Setup sock proxy
-RUN yum install -y openssh openssh-clients openssh-server && yum -y clean all
 RUN ssh-keygen -t rsa -b 4096 -C "automation@trino.io" -N "" -f /root/.ssh/id_rsa \
   && ssh-keygen -t rsa -b 4096 -N "" -f /etc/ssh/ssh_host_rsa_key \
   && ssh-keygen -t dsa -b 1024 -N "" -f /etc/ssh/ssh_host_dsa_key \
@@ -73,6 +33,7 @@ RUN set -xeu; \
     for user in root hive hdfs; do \
         # ~hive might be owned by root
         chown -R "${user}:" "$(eval echo ~"${user}")"; \
+        sudo -u "${user}" bash -c ' echo "" > ~/.bash_history '; \
         sudo -u "${user}" bash -c ' echo "netstat -ltnp" >> ~/.bash_history '; \
         sudo -u "${user}" bash -c ' echo "beeline -u jdbc:hive2://localhost:10000/default -n hive" >> ~/.bash_history '; \
         sudo -u "${user}" bash -c ' echo "hadoop dfs -ls -R /user/hive/warehouse" >> ~/.bash_history '; \

--- a/testing/hdp2.6-hive/files/etc/hadoop/conf/core-site.xml
+++ b/testing/hdp2.6-hive/files/etc/hadoop/conf/core-site.xml
@@ -19,7 +19,7 @@
 
     <property>
         <name>fs.defaultFS</name>
-        <value>hdfs://hadoop-master:9000</value>
+        <value>hdfs://hadoop:9000</value>
     </property>
 
     <!-- OOZIE proxy user setting -->

--- a/testing/hdp2.6-hive/files/etc/hadoop/conf/hdfs-site.xml
+++ b/testing/hdp2.6-hive/files/etc/hadoop/conf/hdfs-site.xml
@@ -27,7 +27,7 @@
 
     <property>
         <name>fs.viewfs.mounttable.hadoop-viewfs.link./default</name>
-        <value>hdfs://hadoop-master:9000/user/hive/warehouse</value>
+        <value>hdfs://hadoop:9000/user/hive/warehouse</value>
     </property>
 
 </configuration>

--- a/testing/hdp2.6-hive/files/etc/hadoop/conf/mapred-site.xml
+++ b/testing/hdp2.6-hive/files/etc/hadoop/conf/mapred-site.xml
@@ -19,7 +19,7 @@
 
     <property>
         <name>mapred.job.tracker</name>
-        <value>hadoop-master:8021</value>
+        <value>hadoop:8021</value>
     </property>
 
     <property>
@@ -29,12 +29,12 @@
 
     <property>
         <name>mapreduce.jobhistory.address</name>
-        <value>hadoop-master:10020</value>
+        <value>hadoop:10020</value>
     </property>
 
     <property>
         <name>mapreduce.jobhistory.webapp.address</name>
-        <value>hadoop-master:19888</value>
+        <value>hadoop:19888</value>
     </property>
 
     <property>

--- a/testing/hdp2.6-hive/files/etc/hadoop/conf/yarn-site.xml
+++ b/testing/hdp2.6-hive/files/etc/hadoop/conf/yarn-site.xml
@@ -74,7 +74,7 @@
 
     <property>
         <name>yarn.resourcemanager.hostname</name>
-        <value>hadoop-master</value>
+        <value>hadoop</value>
     </property>
 
     <property>
@@ -104,7 +104,7 @@
 
     <property>
         <name>yarn.log.server.url</name>
-        <value>http://hadoop-master:19888/jobhistory/logs</value>
+        <value>http://hadoop:19888/jobhistory/logs</value>
     </property>
 
 </configuration>

--- a/testing/hdp2.6-hive/files/root/setup.sh
+++ b/testing/hdp2.6-hive/files/root/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 # make file system hostname resolvable
-echo "127.0.0.1 hadoop-master" >> /etc/hosts
+echo "127.0.0.1 hadoop" >> /etc/hosts
 
 # format namenode
 chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/

--- a/testing/hdp3.1-hive-kerberized/Dockerfile
+++ b/testing/hdp3.1-hive-kerberized/Dockerfile
@@ -68,18 +68,18 @@ RUN /usr/sbin/kadmin.local -q "addprinc -pw 123456 krbtgt/LABS.TERADATA.COM@OTHE
 RUN /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "addprinc -pw 123456 krbtgt/LABS.TERADATA.COM"
 
 # CREATE TRINO PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-master.docker.cluster@LABS.TERADATA.COM" \
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
   && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker.docker.cluster@LABS.TERADATA.COM" \
   && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-1.docker.cluster@LABS.TERADATA.COM" \
   && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-2.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-master.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
   && mkdir -p /etc/trino/conf \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server.keytab trino-server/trino-master.docker.cluster trino-server/trino-worker.docker.cluster trino-server/trino-worker-1.docker.cluster trino-server/trino-worker-2.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server-HTTP.keytab HTTP/trino-master.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-client.keytab trino-client/trino-master.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/hive-trino-master.keytab hive/trino-master.docker.cluster"
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server.keytab trino-server/trino-coordinator.docker.cluster trino-server/trino-worker.docker.cluster trino-server/trino-worker-1.docker.cluster trino-server/trino-worker-2.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server-HTTP.keytab HTTP/trino-coordinator.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-client.keytab trino-client/trino-coordinator.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/hive-trino-coordinator.keytab hive/trino-coordinator.docker.cluster"
 RUN chmod 644 /etc/trino/conf/*.keytab
 
 # CREATE SSL KEYSTORE
@@ -89,7 +89,7 @@ RUN keytool -genkeypair \
     -keystore /etc/trino/conf/keystore.jks \
     -keypass password \
     -storepass password \
-    -dname "CN=trino-master, OU=, O=, L=, S=, C=" \
+    -dname "CN=trino-coordinator, OU=, O=, L=, S=, C=" \
     -validity 100000
 RUN chmod 644 /etc/trino/conf/keystore.jks
 

--- a/testing/hdp3.1-hive-kerberized/Dockerfile
+++ b/testing/hdp3.1-hive-kerberized/Dockerfile
@@ -29,16 +29,16 @@ RUN /usr/sbin/kdb5_util create -s -P password
 RUN /usr/sbin/kdb5_util create -d /var/kerberos/krb5kdc/principal-other -r OTHERLABS.TRINO.IO -s -P password
 
 # ADD HADOOP PRINCIPALS
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey hdfs/hadoop-master@LABS.TRINO.IO" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey mapred/hadoop-master@LABS.TRINO.IO" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey yarn/hadoop-master@LABS.TRINO.IO" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/hadoop-master@LABS.TRINO.IO"
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hdfs/hadoop@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey mapred/hadoop@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey yarn/hadoop@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/hadoop@LABS.TRINO.IO"
 
 # CREATE HADOOP KEYTAB FILES
-RUN /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/hdfs.keytab hdfs/hadoop-master HTTP/hadoop-master" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/mapred.keytab mapred/hadoop-master HTTP/hadoop-master" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/yarn.keytab yarn/hadoop-master HTTP/hadoop-master" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/HTTP.keytab HTTP/hadoop-master"
+RUN /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/hdfs.keytab hdfs/hadoop HTTP/hadoop" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/mapred.keytab mapred/hadoop HTTP/hadoop" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/yarn.keytab yarn/hadoop HTTP/hadoop" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/HTTP.keytab HTTP/hadoop"
 RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs.keytab \
   && chown mapred:hadoop /etc/hadoop/conf/mapred.keytab \
   && chown yarn:hadoop /etc/hadoop/conf/yarn.keytab \
@@ -46,20 +46,20 @@ RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs.keytab \
   && chmod 644 /etc/hadoop/conf/*.keytab
 
 # CREATE HIVE PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop-master@LABS.TRINO.IO" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hive/conf/hive.keytab hive/hadoop-master"
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hive/conf/hive.keytab hive/hadoop"
 RUN chown hive:hadoop /etc/hive/conf/hive.keytab \
   && chmod 644 /etc/hive/conf/hive.keytab
 
 # CREATE HIVE PRINCIPAL IN THE OTHER REALM
-RUN /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "addprinc -randkey hive/hadoop-master@OTHERLABS.TRINO.IO" \
-  && /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "xst -norandkey -k /etc/hive/conf/hive-other.keytab hive/hadoop-master"
+RUN /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "addprinc -randkey hive/hadoop@OTHERLABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "xst -norandkey -k /etc/hive/conf/hive-other.keytab hive/hadoop"
 RUN chown hive:hadoop /etc/hive/conf/hive-other.keytab \
   && chmod 644 /etc/hive/conf/hive-other.keytab
 
 # CREATE HDFS PRINCIPAL IN OTHER REALM
-RUN /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "addprinc -randkey hdfs/hadoop-master@OTHERLABS.TRINO.IO" \
-  && /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "xst -norandkey -k /etc/hadoop/conf/hdfs-other.keytab hdfs/hadoop-master"
+RUN /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "addprinc -randkey hdfs/hadoop@OTHERLABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "xst -norandkey -k /etc/hadoop/conf/hdfs-other.keytab hdfs/hadoop"
 RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs-other.keytab \
   && chmod 644 /etc/hadoop/conf/hdfs-other.keytab
 
@@ -97,8 +97,8 @@ RUN chmod 644 /etc/trino/conf/keystore.jks
 RUN set -xeu; \
     for user in root hive hdfs; do \
         sudo -u "${user}" bash -c ' echo "klist -kt /etc/hive/conf/hive.keytab" >> ~/.bash_history '; \
-        sudo -u "${user}" bash -c ' echo "kinit -kt /etc/hive/conf/hive.keytab hive/hadoop-master@LABS.TRINO.IO" >> ~/.bash_history '; \
-        sudo -u "${user}" bash -c ' echo "beeline -u \"jdbc:hive2://hadoop-master:10000/default;principal=hive/hadoop-master@LABS.TRINO.IO\"" >> ~/.bash_history '; \
+        sudo -u "${user}" bash -c ' echo "kinit -kt /etc/hive/conf/hive.keytab hive/hadoop@LABS.TRINO.IO" >> ~/.bash_history '; \
+        sudo -u "${user}" bash -c ' echo "beeline -u \"jdbc:hive2://hadoop:10000/default;principal=hive/hadoop@LABS.TRINO.IO\"" >> ~/.bash_history '; \
     done
 
 # EXPOSE KERBEROS PORTS

--- a/testing/hdp3.1-hive-kerberized/Dockerfile
+++ b/testing/hdp3.1-hive-kerberized/Dockerfile
@@ -89,7 +89,7 @@ RUN keytool -genkeypair \
     -keystore /etc/trino/conf/keystore.jks \
     -keypass password \
     -storepass password \
-    -dname "CN=trino-coordinator, OU=, O=, L=, S=, C=" \
+    -dname "OU=, O=, L=, S=, C=" \
     -validity 100000
 RUN chmod 644 /etc/trino/conf/keystore.jks
 

--- a/testing/hdp3.1-hive-kerberized/Dockerfile
+++ b/testing/hdp3.1-hive-kerberized/Dockerfile
@@ -26,13 +26,13 @@ RUN /usr/local/bin/apply-all-site-xml-overrides /overrides
 RUN /usr/sbin/kdb5_util create -s -P password
 
 # CREATE ANOTHER KERBEROS DATABASE
-RUN /usr/sbin/kdb5_util create -d /var/kerberos/krb5kdc/principal-other -r OTHERLABS.TERADATA.COM -s -P password
+RUN /usr/sbin/kdb5_util create -d /var/kerberos/krb5kdc/principal-other -r OTHERLABS.TRINO.IO -s -P password
 
 # ADD HADOOP PRINCIPALS
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey hdfs/hadoop-master@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey mapred/hadoop-master@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey yarn/hadoop-master@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/hadoop-master@LABS.TERADATA.COM"
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hdfs/hadoop-master@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey mapred/hadoop-master@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey yarn/hadoop-master@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/hadoop-master@LABS.TRINO.IO"
 
 # CREATE HADOOP KEYTAB FILES
 RUN /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/hdfs.keytab hdfs/hadoop-master HTTP/hadoop-master" \
@@ -46,35 +46,35 @@ RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs.keytab \
   && chmod 644 /etc/hadoop/conf/*.keytab
 
 # CREATE HIVE PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop-master@LABS.TERADATA.COM" \
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop-master@LABS.TRINO.IO" \
   && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hive/conf/hive.keytab hive/hadoop-master"
 RUN chown hive:hadoop /etc/hive/conf/hive.keytab \
   && chmod 644 /etc/hive/conf/hive.keytab
 
 # CREATE HIVE PRINCIPAL IN THE OTHER REALM
-RUN /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "addprinc -randkey hive/hadoop-master@OTHERLABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "xst -norandkey -k /etc/hive/conf/hive-other.keytab hive/hadoop-master"
+RUN /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "addprinc -randkey hive/hadoop-master@OTHERLABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "xst -norandkey -k /etc/hive/conf/hive-other.keytab hive/hadoop-master"
 RUN chown hive:hadoop /etc/hive/conf/hive-other.keytab \
   && chmod 644 /etc/hive/conf/hive-other.keytab
 
 # CREATE HDFS PRINCIPAL IN OTHER REALM
-RUN /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "addprinc -randkey hdfs/hadoop-master@OTHERLABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "xst -norandkey -k /etc/hadoop/conf/hdfs-other.keytab hdfs/hadoop-master"
+RUN /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "addprinc -randkey hdfs/hadoop-master@OTHERLABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "xst -norandkey -k /etc/hadoop/conf/hdfs-other.keytab hdfs/hadoop-master"
 RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs-other.keytab \
   && chmod 644 /etc/hadoop/conf/hdfs-other.keytab
 
-# MAKE 'LABS.TERADATA.COM' TRUST 'OTHERLABS.TERADATA.COM'
-RUN /usr/sbin/kadmin.local -q "addprinc -pw 123456 krbtgt/LABS.TERADATA.COM@OTHERLABS.TERADATA.COM"
-RUN /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "addprinc -pw 123456 krbtgt/LABS.TERADATA.COM"
+# MAKE 'LABS.TRINO.IO' TRUST 'OTHERLABS.TRINO.IO'
+RUN /usr/sbin/kadmin.local -q "addprinc -pw 123456 krbtgt/LABS.TRINO.IO@OTHERLABS.TRINO.IO"
+RUN /usr/sbin/kadmin.local -r OTHERLABS.TRINO.IO -d /var/kerberos/krb5kdc/principal-other -q "addprinc -pw 123456 krbtgt/LABS.TRINO.IO"
 
 # CREATE TRINO PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-1.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-2.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-coordinator.docker.cluster@LABS.TERADATA.COM" \
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-coordinator.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-1.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-2.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-coordinator.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-coordinator.docker.cluster@LABS.TRINO.IO" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-coordinator.docker.cluster@LABS.TRINO.IO" \
   && mkdir -p /etc/trino/conf \
   && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server.keytab trino-server/trino-coordinator.docker.cluster trino-server/trino-worker.docker.cluster trino-server/trino-worker-1.docker.cluster trino-server/trino-worker-2.docker.cluster" \
   && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server-HTTP.keytab HTTP/trino-coordinator.docker.cluster" \
@@ -97,8 +97,8 @@ RUN chmod 644 /etc/trino/conf/keystore.jks
 RUN set -xeu; \
     for user in root hive hdfs; do \
         sudo -u "${user}" bash -c ' echo "klist -kt /etc/hive/conf/hive.keytab" >> ~/.bash_history '; \
-        sudo -u "${user}" bash -c ' echo "kinit -kt /etc/hive/conf/hive.keytab hive/hadoop-master@LABS.TERADATA.COM" >> ~/.bash_history '; \
-        sudo -u "${user}" bash -c ' echo "beeline -u \"jdbc:hive2://hadoop-master:10000/default;principal=hive/hadoop-master@LABS.TERADATA.COM\"" >> ~/.bash_history '; \
+        sudo -u "${user}" bash -c ' echo "kinit -kt /etc/hive/conf/hive.keytab hive/hadoop-master@LABS.TRINO.IO" >> ~/.bash_history '; \
+        sudo -u "${user}" bash -c ' echo "beeline -u \"jdbc:hive2://hadoop-master:10000/default;principal=hive/hadoop-master@LABS.TRINO.IO\"" >> ~/.bash_history '; \
     done
 
 # EXPOSE KERBEROS PORTS

--- a/testing/hdp3.1-hive-kerberized/Dockerfile
+++ b/testing/hdp3.1-hive-kerberized/Dockerfile
@@ -67,29 +67,29 @@ RUN chown hdfs:hadoop /etc/hadoop/conf/hdfs-other.keytab \
 RUN /usr/sbin/kadmin.local -q "addprinc -pw 123456 krbtgt/LABS.TERADATA.COM@OTHERLABS.TERADATA.COM"
 RUN /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "addprinc -pw 123456 krbtgt/LABS.TERADATA.COM"
 
-# CREATE PRESTO PRINCIPAL AND KEYTAB
-RUN /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker-1.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker-2.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/presto-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey presto-client/presto-master.docker.cluster@LABS.TERADATA.COM" \
-  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/presto-master.docker.cluster@LABS.TERADATA.COM" \
+# CREATE TRINO PRINCIPAL AND KEYTAB
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-master.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-1.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-server/trino-worker-2.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/trino-master.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey trino-client/trino-master.docker.cluster@LABS.TERADATA.COM" \
+  && /usr/sbin/kadmin.local -q "addprinc -randkey hive/trino-master.docker.cluster@LABS.TERADATA.COM" \
   && mkdir -p /etc/trino/conf \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/presto-server.keytab presto-server/presto-master.docker.cluster presto-server/presto-worker.docker.cluster presto-server/presto-worker-1.docker.cluster presto-server/presto-worker-2.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/presto-server-HTTP.keytab HTTP/presto-master.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/presto-client.keytab presto-client/presto-master.docker.cluster" \
-  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/hive-presto-master.keytab hive/presto-master.docker.cluster"
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server.keytab trino-server/trino-master.docker.cluster trino-server/trino-worker.docker.cluster trino-server/trino-worker-1.docker.cluster trino-server/trino-worker-2.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-server-HTTP.keytab HTTP/trino-master.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/trino-client.keytab trino-client/trino-master.docker.cluster" \
+  && /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/trino/conf/hive-trino-master.keytab hive/trino-master.docker.cluster"
 RUN chmod 644 /etc/trino/conf/*.keytab
 
 # CREATE SSL KEYSTORE
 RUN keytool -genkeypair \
-    -alias presto \
+    -alias trino \
     -keyalg RSA \
     -keystore /etc/trino/conf/keystore.jks \
     -keypass password \
     -storepass password \
-    -dname "CN=presto-master, OU=, O=, L=, S=, C=" \
+    -dname "CN=trino-master, OU=, O=, L=, S=, C=" \
     -validity 100000
 RUN chmod 644 /etc/trino/conf/keystore.jks
 

--- a/testing/hdp3.1-hive-kerberized/files/etc/krb5.conf
+++ b/testing/hdp3.1-hive-kerberized/files/etc/krb5.conf
@@ -11,10 +11,10 @@
 
 [realms]
  LABS.TRINO.IO = {
-  kdc = hadoop-master:88
-  admin_server = hadoop-master
+  kdc = hadoop:88
+  admin_server = hadoop
  }
  OTHERLABS.TRINO.IO = {
-  kdc = hadoop-master:89
-  admin_server = hadoop-master
+  kdc = hadoop:89
+  admin_server = hadoop
  }

--- a/testing/hdp3.1-hive-kerberized/files/etc/krb5.conf
+++ b/testing/hdp3.1-hive-kerberized/files/etc/krb5.conf
@@ -4,17 +4,17 @@
  admin_server = FILE:/var/log/kadmind.log
 
 [libdefaults]
- default_realm = LABS.TERADATA.COM
+ default_realm = LABS.TRINO.IO
  dns_lookup_realm = false
  dns_lookup_kdc = false
  forwardable = true
 
 [realms]
- LABS.TERADATA.COM = {
+ LABS.TRINO.IO = {
   kdc = hadoop-master:88
   admin_server = hadoop-master
  }
- OTHERLABS.TERADATA.COM = {
+ OTHERLABS.TRINO.IO = {
   kdc = hadoop-master:89
   admin_server = hadoop-master
  }

--- a/testing/hdp3.1-hive-kerberized/files/etc/supervisord.d/kdc.conf
+++ b/testing/hdp3.1-hive-kerberized/files/etc/supervisord.d/kdc.conf
@@ -1,5 +1,5 @@
 [program:krb5kdc]
-command=/bin/bash -c "exec /usr/sbin/krb5kdc -P /var/run/krb5kdc.pid -n -r LABS.TERADATA.COM -n -d /var/kerberos/krb5kdc/principal-other -r OTHERLABS.TERADATA.COM"
+command=/bin/bash -c "exec /usr/sbin/krb5kdc -P /var/run/krb5kdc.pid -n -r LABS.TRINO.IO -n -d /var/kerberos/krb5kdc/principal-other -r OTHERLABS.TRINO.IO"
 autostart=true
 autorestart=true
 redirect_stderr=true
@@ -7,7 +7,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:kadmind]
-command=/bin/bash -c "exec /usr/sbin/kadmind -P /var/run/kadmind.pid -nofork -r LABS.TERADATA.COM"
+command=/bin/bash -c "exec /usr/sbin/kadmind -P /var/run/kadmind.pid -nofork -r LABS.TRINO.IO"
 autostart=true
 autorestart=true
 redirect_stderr=true

--- a/testing/hdp3.1-hive-kerberized/files/overrides/etc/hadoop/conf/core-site.xml
+++ b/testing/hdp3.1-hive-kerberized/files/overrides/etc/hadoop/conf/core-site.xml
@@ -42,7 +42,7 @@
     <property>
         <name>hadoop.security.auth_to_local</name>
         <value>
-            RULE:[2:$1@$0](.*@OTHERLABS.TERADATA.COM)s/@.*//
+            RULE:[2:$1@$0](.*@OTHERLABS.TRINO.IO)s/@.*//
             DEFAULT
         </value>
     </property>

--- a/testing/hdp3.1-hive-kerberized/files/overrides/etc/hadoop/conf/hdfs-site.xml
+++ b/testing/hdp3.1-hive-kerberized/files/overrides/etc/hadoop/conf/hdfs-site.xml
@@ -27,11 +27,11 @@
     </property>
     <property>
         <name>dfs.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
+        <value>hdfs/hadoop@LABS.TRINO.IO</value>
     </property>
     <property>
         <name>dfs.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
+        <value>HTTP/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- Secondary NameNode security config -->
@@ -41,11 +41,11 @@
     </property>
     <property>
         <name>dfs.secondary.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
+        <value>hdfs/hadoop@LABS.TRINO.IO</value>
     </property>
     <property>
         <name>dfs.secondary.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
+        <value>HTTP/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- DataNode security config -->
@@ -55,7 +55,7 @@
     </property>
     <property>
         <name>dfs.datanode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
+        <value>hdfs/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- WebHDFS security config -->
@@ -67,7 +67,7 @@
     <!-- Web Authentication config -->
     <property>
         <name>dfs.web.authentication.kerberos.principal</name>
-        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
+        <value>HTTP/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>

--- a/testing/hdp3.1-hive-kerberized/files/overrides/etc/hadoop/conf/hdfs-site.xml
+++ b/testing/hdp3.1-hive-kerberized/files/overrides/etc/hadoop/conf/hdfs-site.xml
@@ -27,11 +27,11 @@
     </property>
     <property>
         <name>dfs.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
     </property>
     <property>
         <name>dfs.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master@LABS.TERADATA.COM</value>
+        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- Secondary NameNode security config -->
@@ -41,11 +41,11 @@
     </property>
     <property>
         <name>dfs.secondary.namenode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
     </property>
     <property>
         <name>dfs.secondary.namenode.kerberos.internal.spnego.principal</name>
-        <value>HTTP/hadoop-master@LABS.TERADATA.COM</value>
+        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- DataNode security config -->
@@ -55,7 +55,7 @@
     </property>
     <property>
         <name>dfs.datanode.kerberos.principal</name>
-        <value>hdfs/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hdfs/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- WebHDFS security config -->
@@ -67,7 +67,7 @@
     <!-- Web Authentication config -->
     <property>
         <name>dfs.web.authentication.kerberos.principal</name>
-        <value>HTTP/hadoop-master@LABS.TERADATA.COM</value>
+        <value>HTTP/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>

--- a/testing/hdp3.1-hive-kerberized/files/overrides/etc/hadoop/conf/mapred-site.xml
+++ b/testing/hdp3.1-hive-kerberized/files/overrides/etc/hadoop/conf/mapred-site.xml
@@ -25,13 +25,13 @@
 
     <property>
         <name>mapreduce.jobhistory.principal</name>
-        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
+        <value>mapred/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- JobTracker security configs -->
     <property>
         <name>mapreduce.jobtracker.kerberos.principal</name>
-        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
+        <value>mapred/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>
@@ -42,7 +42,7 @@
     <!-- TaskTracker security configs -->
     <property>
         <name>mapreduce.tasktracker.kerberos.principal</name>
-        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
+        <value>mapred/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>

--- a/testing/hdp3.1-hive-kerberized/files/overrides/etc/hadoop/conf/mapred-site.xml
+++ b/testing/hdp3.1-hive-kerberized/files/overrides/etc/hadoop/conf/mapred-site.xml
@@ -25,13 +25,13 @@
 
     <property>
         <name>mapreduce.jobhistory.principal</name>
-        <value>mapred/hadoop-master@LABS.TERADATA.COM</value>
+        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- JobTracker security configs -->
     <property>
         <name>mapreduce.jobtracker.kerberos.principal</name>
-        <value>mapred/hadoop-master@LABS.TERADATA.COM</value>
+        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>
@@ -42,7 +42,7 @@
     <!-- TaskTracker security configs -->
     <property>
         <name>mapreduce.tasktracker.kerberos.principal</name>
-        <value>mapred/hadoop-master@LABS.TERADATA.COM</value>
+        <value>mapred/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>

--- a/testing/hdp3.1-hive-kerberized/files/overrides/etc/hadoop/conf/yarn-site.xml
+++ b/testing/hdp3.1-hive-kerberized/files/overrides/etc/hadoop/conf/yarn-site.xml
@@ -26,7 +26,7 @@
 
     <property>
         <name>yarn.resourcemanager.principal</name>
-        <value>yarn/hadoop-master@LABS.TERADATA.COM</value>
+        <value>yarn/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- NodeManager security configs -->
@@ -37,7 +37,7 @@
 
     <property>
         <name>yarn.nodemanager.principal</name>
-        <value>yarn/hadoop-master@LABS.TERADATA.COM</value>
+        <value>yarn/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
 </configuration>

--- a/testing/hdp3.1-hive-kerberized/files/overrides/etc/hadoop/conf/yarn-site.xml
+++ b/testing/hdp3.1-hive-kerberized/files/overrides/etc/hadoop/conf/yarn-site.xml
@@ -26,7 +26,7 @@
 
     <property>
         <name>yarn.resourcemanager.principal</name>
-        <value>yarn/hadoop-master@LABS.TRINO.IO</value>
+        <value>yarn/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- NodeManager security configs -->
@@ -37,7 +37,7 @@
 
     <property>
         <name>yarn.nodemanager.principal</name>
-        <value>yarn/hadoop-master@LABS.TRINO.IO</value>
+        <value>yarn/hadoop@LABS.TRINO.IO</value>
     </property>
 
 </configuration>

--- a/testing/hdp3.1-hive-kerberized/files/overrides/etc/hive/conf/hive-site.xml
+++ b/testing/hdp3.1-hive-kerberized/files/overrides/etc/hive/conf/hive-site.xml
@@ -30,7 +30,7 @@
 
     <property>
         <name>hive.server2.authentication.kerberos.principal</name>
-        <value>hive/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hive/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <property>
@@ -50,7 +50,7 @@
 
     <property>
         <name>hive.metastore.kerberos.principal</name>
-        <value>hive/hadoop-master@LABS.TERADATA.COM</value>
+        <value>hive/hadoop-master@LABS.TRINO.IO</value>
     </property>
 
     <!-- Enable SQL based authorization -->

--- a/testing/hdp3.1-hive-kerberized/files/overrides/etc/hive/conf/hive-site.xml
+++ b/testing/hdp3.1-hive-kerberized/files/overrides/etc/hive/conf/hive-site.xml
@@ -30,7 +30,7 @@
 
     <property>
         <name>hive.server2.authentication.kerberos.principal</name>
-        <value>hive/hadoop-master@LABS.TRINO.IO</value>
+        <value>hive/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <property>
@@ -50,7 +50,7 @@
 
     <property>
         <name>hive.metastore.kerberos.principal</name>
-        <value>hive/hadoop-master@LABS.TRINO.IO</value>
+        <value>hive/hadoop@LABS.TRINO.IO</value>
     </property>
 
     <!-- Enable SQL based authorization -->

--- a/testing/hdp3.1-hive-kerberized/files/var/kerberos/krb5kdc/kadm5-other.acl
+++ b/testing/hdp3.1-hive-kerberized/files/var/kerberos/krb5kdc/kadm5-other.acl
@@ -1,1 +1,1 @@
-*/admin@OTHERLABS.TERADATA.COM *
+*/admin@OTHERLABS.TRINO.IO *

--- a/testing/hdp3.1-hive-kerberized/files/var/kerberos/krb5kdc/kadm5.acl
+++ b/testing/hdp3.1-hive-kerberized/files/var/kerberos/krb5kdc/kadm5.acl
@@ -1,1 +1,1 @@
-*/admin@LABS.TERADATA.COM	*
+*/admin@LABS.TRINO.IO	*

--- a/testing/hdp3.1-hive-kerberized/files/var/kerberos/krb5kdc/kdc.conf
+++ b/testing/hdp3.1-hive-kerberized/files/var/kerberos/krb5kdc/kdc.conf
@@ -3,14 +3,14 @@
  kdc_tcp_ports = 88
 
 [realms]
- LABS.TERADATA.COM = {
+ LABS.TRINO.IO = {
   acl_file = /var/kerberos/krb5kdc/kadm5.acl
   dict_file = /usr/share/dict/words
   admin_keytab = /var/kerberos/krb5kdc/kadm5.keytab
   supported_enctypes = aes128-cts:normal des3-hmac-sha1:normal arcfour-hmac:normal des-hmac-sha1:normal des-cbc-md5:normal des-cbc-crc:normal
  }
 
- OTHERLABS.TERADATA.COM = {
+ OTHERLABS.TRINO.IO = {
   acl_file = /var/kerberos/krb5kdc/kadm5-other.acl
   dict_file = /usr/share/dict/words
   admin_keytab = /var/kerberos/krb5kdc/kadm5-other.keytab

--- a/testing/hdp3.1-hive/Dockerfile
+++ b/testing/hdp3.1-hive/Dockerfile
@@ -10,51 +10,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM testing/centos7-oj8:unlabelled
-
-# Change default timezone
-RUN ln -snf "/usr/share/zoneinfo/Asia/Kathmandu" /etc/localtime && echo "Asia/Kathmandu" > /etc/timezone
-
-# Install HDP repo
-RUN set -xeu; \
-    wget -nv http://public-repo-1.hortonworks.com/HDP/centos7/3.x/updates/3.1.0.0/hdp.repo -P /etc/yum.repos.d; \
-    wget -nv http://public-repo-1.hortonworks.com/HDP-GPL/centos7/3.x/updates/3.1.0.0/hdp.gpl.repo -P /etc/yum.repos.d; \
-    echo OK
-
-# Install Hadoop, Hive
-RUN yum install -y \
-    hadoop-hdfs-namenode \
-    hadoop-hdfs-secondarynamenode \
-    hadoop-hdfs-datanode \
-
-    hadoop-yarn-resourcemanager \
-    hadoop-yarn-nodemanager \
-
-    hive \
-    hive-metastore \
-    hive-server2 \
-    tez \
-
-    hadooplzo \
-    hadooplzo-native \
-    lzo \
-    lzo-devel \
-    lzop \
-
-    # Mysql is not present in Centos7 repositories, use mariadb as a replacement
-    mariadb-server \
-    mysql-connector-java \
-
-# Cleanup
-  && yum -y clean all && rm -rf /tmp/* /var/tmp/* \
-  && ln -s /usr/share/java/mysql-connector-java.jar /usr/hdp/current/hive-metastore/lib/mysql-connector-java.jar
-
-# Delete original configuration
-RUN rm -r /etc/hadoop/conf/* \
-  && rm -r /etc/hive/conf/*
+# Use last layer from ghcr.io/trinodb/testing/hdp3.1-hive:38
+FROM f6949adf3207
 
 # Copy configuration files
 COPY ./files /
+
+# Remove old SSH keys
+RUN rm -Rf /root/.ssh/* /etc/ssh/ssh_host_rsa_key /etc/ssh/ssh_host_dsa_key
+
+RUN yum-config-manager --disable HDP-GPL-3.1.0.0
 
 # Setup sock proxy
 RUN yum install -y openssh openssh-clients openssh-server && yum -y clean all
@@ -65,14 +30,11 @@ RUN ssh-keygen -t rsa -b 4096 -C "automation@trino.io" -N "" -f /root/.ssh/id_rs
 RUN chmod 755 /root && chmod 700 /root/.ssh
 RUN passwd --unlock root
 
-# Run setup script
-RUN /root/setup.sh \
-  && rm -rf /tmp/* /var/tmp/*
-
 # Provide convenience bash history
 RUN set -xeu; \
     echo "supervisorctl restart all" >> ~root/.bash_history; \
     for user in root hive hdfs; do \
+        sudo -u "${user}" bash -c ' echo "" > ~/.bash_history '; \
         sudo -u "${user}" bash -c ' echo "netstat -ltnp" >> ~/.bash_history '; \
         sudo -u "${user}" bash -c ' echo "beeline -n hive" >> ~/.bash_history '; \
         sudo -u "${user}" bash -c ' echo "hdfs dfs -ls -R /user/hive/warehouse" >> ~/.bash_history '; \

--- a/testing/hdp3.1-hive/Dockerfile
+++ b/testing/hdp3.1-hive/Dockerfile
@@ -10,16 +10,51 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use last layer from ghcr.io/trinodb/testing/hdp3.1-hive:38
-FROM f6949adf3207
+FROM testing/centos7-oj8:unlabelled
+
+# Change default timezone
+RUN ln -snf "/usr/share/zoneinfo/Asia/Kathmandu" /etc/localtime && echo "Asia/Kathmandu" > /etc/timezone
+
+# Install HDP repo
+RUN set -xeu; \
+    wget -nv http://public-repo-1.hortonworks.com/HDP/centos7/3.x/updates/3.1.0.0/hdp.repo -P /etc/yum.repos.d; \
+    wget -nv http://public-repo-1.hortonworks.com/HDP-GPL/centos7/3.x/updates/3.1.0.0/hdp.gpl.repo -P /etc/yum.repos.d; \
+    echo OK
+
+# Install Hadoop, Hive
+RUN yum install -y \
+    hadoop-hdfs-namenode \
+    hadoop-hdfs-secondarynamenode \
+    hadoop-hdfs-datanode \
+
+    hadoop-yarn-resourcemanager \
+    hadoop-yarn-nodemanager \
+
+    hive \
+    hive-metastore \
+    hive-server2 \
+    tez \
+
+    hadooplzo \
+    hadooplzo-native \
+    lzo \
+    lzo-devel \
+    lzop \
+
+    # Mysql is not present in Centos7 repositories, use mariadb as a replacement
+    mariadb-server \
+    mysql-connector-java \
+
+# Cleanup
+  && yum -y clean all && rm -rf /tmp/* /var/tmp/* \
+  && ln -s /usr/share/java/mysql-connector-java.jar /usr/hdp/current/hive-metastore/lib/mysql-connector-java.jar
+
+# Delete original configuration
+RUN rm -r /etc/hadoop/conf/* \
+  && rm -r /etc/hive/conf/*
 
 # Copy configuration files
 COPY ./files /
-
-# Remove old SSH keys
-RUN rm -Rf /root/.ssh/* /etc/ssh/ssh_host_rsa_key /etc/ssh/ssh_host_dsa_key
-
-RUN yum-config-manager --disable HDP-GPL-3.1.0.0
 
 # Setup sock proxy
 RUN yum install -y openssh openssh-clients openssh-server && yum -y clean all
@@ -30,11 +65,14 @@ RUN ssh-keygen -t rsa -b 4096 -C "automation@trino.io" -N "" -f /root/.ssh/id_rs
 RUN chmod 755 /root && chmod 700 /root/.ssh
 RUN passwd --unlock root
 
+# Run setup script
+RUN /root/setup.sh \
+  && rm -rf /tmp/* /var/tmp/*
+
 # Provide convenience bash history
 RUN set -xeu; \
     echo "supervisorctl restart all" >> ~root/.bash_history; \
     for user in root hive hdfs; do \
-        sudo -u "${user}" bash -c ' echo "" > ~/.bash_history '; \
         sudo -u "${user}" bash -c ' echo "netstat -ltnp" >> ~/.bash_history '; \
         sudo -u "${user}" bash -c ' echo "beeline -n hive" >> ~/.bash_history '; \
         sudo -u "${user}" bash -c ' echo "hdfs dfs -ls -R /user/hive/warehouse" >> ~/.bash_history '; \

--- a/testing/hdp3.1-hive/files/etc/hadoop/conf/core-site.xml
+++ b/testing/hdp3.1-hive/files/etc/hadoop/conf/core-site.xml
@@ -19,7 +19,7 @@
 
     <property>
         <name>fs.defaultFS</name>
-        <value>hdfs://hadoop-master:9000</value>
+        <value>hdfs://hadoop:9000</value>
     </property>
 
     <!-- OOZIE proxy user setting -->

--- a/testing/hdp3.1-hive/files/etc/hadoop/conf/hdfs-site.xml
+++ b/testing/hdp3.1-hive/files/etc/hadoop/conf/hdfs-site.xml
@@ -27,7 +27,7 @@
 
     <property>
         <name>fs.viewfs.mounttable.hadoop-viewfs.link./default</name>
-        <value>hdfs://hadoop-master:9000/user/hive/warehouse</value>
+        <value>hdfs://hadoop:9000/user/hive/warehouse</value>
     </property>
 
     <!-- This property explicitly forbids datanode to enter safe mode which results in 30 s penalty on environment startup -->

--- a/testing/hdp3.1-hive/files/etc/hadoop/conf/mapred-site.xml
+++ b/testing/hdp3.1-hive/files/etc/hadoop/conf/mapred-site.xml
@@ -19,7 +19,7 @@
 
     <property>
         <name>mapred.job.tracker</name>
-        <value>hadoop-master:8021</value>
+        <value>hadoop:8021</value>
     </property>
 
     <property>
@@ -29,12 +29,12 @@
 
     <property>
         <name>mapreduce.jobhistory.address</name>
-        <value>hadoop-master:10020</value>
+        <value>hadoop:10020</value>
     </property>
 
     <property>
         <name>mapreduce.jobhistory.webapp.address</name>
-        <value>hadoop-master:19888</value>
+        <value>hadoop:19888</value>
     </property>
 
     <property>

--- a/testing/hdp3.1-hive/files/etc/hadoop/conf/yarn-site.xml
+++ b/testing/hdp3.1-hive/files/etc/hadoop/conf/yarn-site.xml
@@ -74,7 +74,7 @@
 
     <property>
         <name>yarn.resourcemanager.hostname</name>
-        <value>hadoop-master</value>
+        <value>hadoop</value>
     </property>
 
     <property>
@@ -104,7 +104,7 @@
 
     <property>
         <name>yarn.log.server.url</name>
-        <value>http://hadoop-master:19888/jobhistory/logs</value>
+        <value>http://hadoop:19888/jobhistory/logs</value>
     </property>
 
     <!-- Minimum container memory, default value is 1024 which is too high for the test queries -->

--- a/testing/hdp3.1-hive/files/root/setup.sh
+++ b/testing/hdp3.1-hive/files/root/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 # make file system hostname resolvable
-echo "127.0.0.1 hadoop-master" >> /etc/hosts
+echo "127.0.0.1 hadoop" >> /etc/hosts
 
 # format namenode
 chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/


### PR DESCRIPTION
While working on https://github.com/trinodb/trino/pull/6516 I've encountered some problems due to previous renaming (proxy user for hadoop impersonation was changed from `presto-server` to `trino-server` but keytabs didn't follow that renaming as well).

I propose to update the naming of keytabs and also change "`presto-master`" to "`trino-coordinator`" (which is a better name than `master`/`slave` nomenclature)

I'd like to also change realm from LABS.TERADATA.COM to sth different but I need some advice here @kokosing 