### PR TITLE
Use Iceberg 0.11.0

### DIFF
--- a/testing/spark3.0-iceberg/Dockerfile
+++ b/testing/spark3.0-iceberg/Dockerfile
@@ -14,7 +14,7 @@ FROM testing/centos7-oj11:unlabelled
 
 ARG SPARK_VERSION=3.0.0
 ARG HADOOP_VERSION=2.7
-ARG ICEBERG_VERSION=0.9.0
+ARG ICEBERG_VERSION=0.11.0
 
 ARG SPARK_ARTIFACT="spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}"
 
@@ -28,10 +28,7 @@ RUN set -xeu; \
 
 WORKDIR ${SPARK_HOME}/jars
 
-# install Iceberg and temporarily add an inadvertent dependency required for Iceberg
-# (see https://github.com/apache/iceberg/pull/1278)
-RUN set -xeu; \
-    wget "https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark3-runtime/${ICEBERG_VERSION}/iceberg-spark3-runtime-${ICEBERG_VERSION}.jar"; \
-    wget "https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.19/commons-compress-1.19.jar"
+# install Iceberg
+RUN wget "https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark3-runtime/${ICEBERG_VERSION}/iceberg-spark3-runtime-${ICEBERG_VERSION}.jar"
 
 ENV PATH="${SPARK_HOME}/bin:${PATH}"

--- a/testing/spark3.0-iceberg/Dockerfile
+++ b/testing/spark3.0-iceberg/Dockerfile
@@ -21,7 +21,7 @@ ARG SPARK_ARTIFACT="spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}"
 ENV SPARK_HOME=/spark
 
 RUN set -xeu; \
-    wget "https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/${SPARK_ARTIFACT}.tgz"; \
+    wget -nv "https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/${SPARK_ARTIFACT}.tgz"; \
     tar -xf ${SPARK_ARTIFACT}.tgz; \
     rm ${SPARK_ARTIFACT}.tgz; \
     ln -sn /${SPARK_ARTIFACT} ${SPARK_HOME}
@@ -29,6 +29,6 @@ RUN set -xeu; \
 WORKDIR ${SPARK_HOME}/jars
 
 # install Iceberg
-RUN wget "https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark3-runtime/${ICEBERG_VERSION}/iceberg-spark3-runtime-${ICEBERG_VERSION}.jar"
+RUN wget -nv "https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark3-runtime/${ICEBERG_VERSION}/iceberg-spark3-runtime-${ICEBERG_VERSION}.jar"
 
 ENV PATH="${SPARK_HOME}/bin:${PATH}"


### PR DESCRIPTION
Ref: https://github.com/trinodb/trino/pull/7049
Also pulled in the change from https://github.com/trinodb/docker-images/pull/67.

Built locally, `TestSparkCompatibility` succeeds.