### PR TITLE
Build accumulo image on the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          - image: accumulo
           - image: dns
           - image: centos7-oj11
           - image: centos7-oj8-openldap-referrals


### PR DESCRIPTION
Previously it was missing and cause release to fail (due to dependency on removed CentOS 6: https://github.com/trinodb/docker-images/pull/95)