### PR TITLE
Restore previous presto-server proxyuser name

### DIFF
--- a/testing/cdh5.12-hive-kerberized/files/overrides/etc/hadoop/conf/core-site.xml
+++ b/testing/cdh5.12-hive-kerberized/files/overrides/etc/hadoop/conf/core-site.xml
@@ -19,12 +19,12 @@
 
     <!-- Trino impersonation -->
     <property>
-        <name>hadoop.proxyuser.trino-server.groups</name>
+        <name>hadoop.proxyuser.presto-server.groups</name>
         <value>*</value>
     </property>
 
     <property>
-        <name>hadoop.proxyuser.trino-server.hosts</name>
+        <name>hadoop.proxyuser.presto-server.hosts</name>
         <value>*</value>
     </property>
 

--- a/testing/cdh5.15-hive-kerberized-kms/files/etc/hadoop/conf/core-site.xml
+++ b/testing/cdh5.15-hive-kerberized-kms/files/etc/hadoop/conf/core-site.xml
@@ -41,12 +41,12 @@
 
     <!-- Trino impersonation -->
     <property>
-        <name>hadoop.proxyuser.trino-server.groups</name>
+        <name>hadoop.proxyuser.presto-server.groups</name>
         <value>*</value>
     </property>
 
     <property>
-        <name>hadoop.proxyuser.trino-server.hosts</name>
+        <name>hadoop.proxyuser.presto-server.hosts</name>
         <value>*</value>
     </property>
 

--- a/testing/cdh5.15-hive-kerberized/files/overrides/etc/hadoop/conf/core-site.xml
+++ b/testing/cdh5.15-hive-kerberized/files/overrides/etc/hadoop/conf/core-site.xml
@@ -19,12 +19,12 @@
 
     <!-- Trino impersonation -->
     <property>
-        <name>hadoop.proxyuser.trino-server.groups</name>
+        <name>hadoop.proxyuser.presto-server.groups</name>
         <value>*</value>
     </property>
 
     <property>
-        <name>hadoop.proxyuser.trino-server.hosts</name>
+        <name>hadoop.proxyuser.presto-server.hosts</name>
         <value>*</value>
     </property>
 

--- a/testing/hdp2.6-hive-kerberized-2/files/overrides/etc/hadoop/conf/core-site.xml
+++ b/testing/hdp2.6-hive-kerberized-2/files/overrides/etc/hadoop/conf/core-site.xml
@@ -24,12 +24,12 @@
 
     <!-- Trino impersonation -->
     <property>
-        <name>hadoop.proxyuser.trino-server.groups</name>
+        <name>hadoop.proxyuser.presto-server.groups</name>
         <value>*</value>
     </property>
 
     <property>
-        <name>hadoop.proxyuser.trino-server.hosts</name>
+        <name>hadoop.proxyuser.presto-server.hosts</name>
         <value>*</value>
     </property>
 

--- a/testing/hdp2.6-hive-kerberized/files/overrides/etc/hadoop/conf/core-site.xml
+++ b/testing/hdp2.6-hive-kerberized/files/overrides/etc/hadoop/conf/core-site.xml
@@ -19,12 +19,12 @@
 
     <!-- Trino impersonation -->
     <property>
-        <name>hadoop.proxyuser.trino-server.groups</name>
+        <name>hadoop.proxyuser.presto-server.groups</name>
         <value>*</value>
     </property>
 
     <property>
-        <name>hadoop.proxyuser.trino-server.hosts</name>
+        <name>hadoop.proxyuser.presto-server.hosts</name>
         <value>*</value>
     </property>
 

--- a/testing/hdp3.1-hive-kerberized/files/overrides/etc/hadoop/conf/core-site.xml
+++ b/testing/hdp3.1-hive-kerberized/files/overrides/etc/hadoop/conf/core-site.xml
@@ -19,12 +19,12 @@
 
     <!-- Trino impersonation -->
     <property>
-        <name>hadoop.proxyuser.trino-server.groups</name>
+        <name>hadoop.proxyuser.presto-server.groups</name>
         <value>*</value>
     </property>
 
     <property>
-        <name>hadoop.proxyuser.trino-server.hosts</name>
+        <name>hadoop.proxyuser.presto-server.hosts</name>
         <value>*</value>
     </property>
 


### PR DESCRIPTION
This change broken OSS Trino automation for hive/hadoop impersonation tests.

It will need to be changed along with the new keytabs and certificates.