### PR TITLE
Revert "Upgrade Zulu JDK to version 17"

### DIFF
--- a/testing/cdh5.12-hive/Dockerfile
+++ b/testing/cdh5.12-hive/Dockerfile
@@ -21,8 +21,8 @@ RUN \
     set -xeu && \
     # Remove unaccessible CDH5 repos so yum is still usable
     rm /etc/yum.repos.d/cloudera-cdh5.repo && \
-    # Upgrade Zulu JDK to 17.0.0
-    rpm -U -i https://cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-linux.x86_64.rpm && \
+    # Upgrade Zulu JDK to 11.0.11
+    rpm -U -i https://cdn.azul.com/zulu/bin/zulu11.48.21-ca-jdk11.0.11-linux.x86_64.rpm && \
     echo "Done"
 
 # HDFS ports

--- a/testing/centos7-oj8/Dockerfile
+++ b/testing/centos7-oj8/Dockerfile
@@ -24,7 +24,7 @@ RUN \
         && \
     \
     # install Zulu JDK (will not be the default `java`)
-    rpm -i https://cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-linux.x86_64.rpm && \
+    rpm -i https://cdn.azul.com/zulu/bin/zulu11.48.21-ca-jdk11.0.11-linux.x86_64.rpm && \
     \
     # install supervisor
     yum --enablerepo=extras install -y setuptools epel-release && \

--- a/testing/hdp2.6-hive/Dockerfile
+++ b/testing/hdp2.6-hive/Dockerfile
@@ -21,8 +21,8 @@ RUN \
     set -xeu && \
     # Remove unaccessible HDP2 repos so yum is still usable
     rm /etc/yum.repos.d/hdp*.repo && \
-    # Upgrade Zulu JDK to 17.0.0
-    rpm -U -i https://cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-linux.x86_64.rpm && \
+    # Upgrade Zulu JDK to 11.0.11
+    rpm -U -i https://cdn.azul.com/zulu/bin/zulu11.48.21-ca-jdk11.0.11-linux.x86_64.rpm && \
     echo "Done"
 
 # HDFS ports

--- a/testing/hdp3.1-hive/Dockerfile
+++ b/testing/hdp3.1-hive/Dockerfile
@@ -21,8 +21,8 @@ RUN \
     set -xeu && \
     # Remove unaccessible HDP3 repos so yum is still usable
     rm /etc/yum.repos.d/hdp*.repo && \
-    # Upgrade Zulu JDK to 17.0.0
-    rpm -U -i https://cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-linux.x86_64.rpm && \
+    # Upgrade Zulu JDK to 11.0.11
+    rpm -U -i https://cdn.azul.com/zulu/bin/zulu11.48.21-ca-jdk11.0.11-linux.x86_64.rpm && \
     echo "Done"
 
 # HDFS ports

--- a/testing/kerberos/Dockerfile
+++ b/testing/kerberos/Dockerfile
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM testing/centos7-oj17:unlabelled
+FROM testing/centos7-oj11:unlabelled
 
 # INSTALL KERBEROS
 RUN yum install -y krb5-libs krb5-server krb5-workstation \

--- a/testing/spark3.0-iceberg/Dockerfile
+++ b/testing/spark3.0-iceberg/Dockerfile
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM testing/centos7-oj17:unlabelled
+FROM testing/centos7-oj11:unlabelled
 
 ARG SPARK_VERSION=3.0.0
 ARG HADOOP_VERSION=2.7


### PR DESCRIPTION
Reverts trinodb/docker-images#104

The PR was merged accidentally. Actuallty it was superseded with https://github.com/trinodb/docker-images/pull/105