### PR TITLE
Centos7 on ARM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
           - image: accumulo
           - image: dns
           - image: centos7-oj11
+          - image: centos7-oj11-arm64
           - image: centos7-oj8-openldap-referrals
           - image: spark3.0-iceberg
           - image: kerberos

--- a/testing/centos7-oj11-arm64/Dockerfile
+++ b/testing/centos7-oj11-arm64/Dockerfile
@@ -1,0 +1,59 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM multiarch/qemu-user-static:x86_64-aarch64 as qemu
+FROM arm64v8/centos:7
+
+ARG ZULU11=zulu11.50.19-ca-jdk11.0.12
+ARG ZULU17=zulu17.28.13-ca-jdk17.0.0
+
+COPY ./files /
+
+# Install Java and presto-admin dependences
+RUN \
+    set -xeu && \
+    yum install -y \
+        nc \
+        wget \
+        curl \
+        && \
+    \
+    # install Zulu JDK
+    curl -fLO https://cdn.azul.com/zulu-embedded/bin/$ZULU11-linux_aarch64.tar.gz && \
+    tar xf $ZULU11-linux_aarch64.tar.gz && \
+    mkdir -p /usr/lib/jvm/ && \
+    mv $ZULU11-linux_aarch64 /usr/lib/jvm/zulu-11 && \
+    # Install additional Zulu JDK 17.0.0
+    curl -fLO https://cdn.azul.com/zulu/bin/$ZULU17-linux_aarch64.tar.gz && \
+    tar xf $ZULU17-linux_aarch64.tar.gz && \
+    mv $ZULU17-linux_aarch64 /usr/lib/jvm/zulu-17 && \
+    \
+    # install supervisor
+    yum --enablerepo=extras install -y setuptools epel-release && \
+    yum install -y python-pip && \
+    pip install supervisor && \
+    \
+    # install commonly needed packages
+    yum install -y \
+        less `# helpful when troubleshooting product tests` \
+        net-tools `# netstat is required by run_on_docker.sh` \
+        sudo \
+        telnet `# helpful when troubleshooting product tests` \
+        vim `# helpful when troubleshooting product tests` \
+        && \
+    # cleanup
+    yum -y clean all && rm -rf /tmp/* /var/tmp/*
+
+COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
+
+ENV PATH="/usr/local/bin:/usr/lib/jvm/zulu-11/bin:${PATH}"
+ENV JAVA_HOME=/usr/lib/jvm/zulu-11

--- a/testing/centos7-oj11-arm64/files/opt/trinodev/site-override.xslt
+++ b/testing/centos7-oj11-arm64/files/opt/trinodev/site-override.xslt
@@ -1,0 +1,17 @@
+<!-- Copied from https://stackoverflow.com/a/31186191/65458 and adapted -->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes" />
+    <xsl:strip-space elements="*" />
+
+    <xsl:variable name="override-properties" select="document($override-path)/configuration/property" />
+
+    <xsl:template match="/configuration">
+        <xsl:copy>
+            <!-- copy local properties not overridden by external properties -->
+            <xsl:copy-of select="property[not(name=$override-properties/name)]" />
+            <!-- add all overriding properties -->
+            <xsl:copy-of select="$override-properties" />
+        </xsl:copy>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/testing/centos7-oj11-arm64/files/usr/local/bin/apply-all-site-xml-overrides
+++ b/testing/centos7-oj11-arm64/files/usr/local/bin/apply-all-site-xml-overrides
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+fail() {
+  echo "$(basename "$0"): $*" >&2
+  exit 1
+}
+
+if [ $# -ne 1 ]; then
+  fail "Usage: $0 <overrides dir>" >&2
+fi
+
+overrides_dir="$1"
+
+for file in $(find $overrides_dir -name '*.xml'); do
+    target_filename="${file#"$overrides_dir"}"
+    echo "Applying configuration override from $file to $target_filename"
+    apply-site-xml-override "$target_filename" "$file"
+done

--- a/testing/centos7-oj11-arm64/files/usr/local/bin/apply-site-xml-override
+++ b/testing/centos7-oj11-arm64/files/usr/local/bin/apply-site-xml-override
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+fail() {
+  echo "$(basename "$0"): $*" >&2
+  exit 1
+}
+
+if [ $# -ne 2 ]; then
+  fail "Usage: $0 <some-site.xml> <overrides.xml>" >&2
+fi
+
+site_xml="$1"
+overrides="$2"
+site_xml_new="$1.new"
+
+test -f "${site_xml}" || fail "${site_xml} does not exist or is not a file"
+test -f "${overrides}" || fail "${overrides} does not exist or is not a file"
+test ! -e "${site_xml_new}" || fail "${site_xml_new} already exists"
+
+xsltproc --param override-path "'${overrides}'" "/opt/trinodev/site-override.xslt" "${site_xml}" > "${site_xml_new}"
+cat "${site_xml_new}" > "${site_xml}" # Preserve file owner & permissions
+rm "${site_xml_new}"

--- a/testing/centos7-oj8-arm64/Dockerfile
+++ b/testing/centos7-oj8-arm64/Dockerfile
@@ -1,0 +1,53 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM multiarch/qemu-user-static:x86_64-aarch64 as qemu
+FROM arm64v8/centos:7
+
+COPY ./files /
+
+# Install Java and presto-admin dependences
+RUN \
+    set -xeu && \
+    yum install -y \
+        java-1.8.0-openjdk-devel \
+        nc \
+        wget \
+        && \
+    \
+    # install Zulu JDK (will not be the default `java`)
+    curl -fLO https://cdn.azul.com/zulu-embedded/bin/zulu11.50.19-ca-jdk11.0.12-linux_aarch64.tar.gz && \
+    tar xf zulu11.50.19-ca-jdk11.0.12-linux_aarch64.tar.gz && \
+    mkdir -p /usr/lib/jvm/ && \
+    mv zulu11.50.19-ca-jdk11.0.12-linux_aarch64 /usr/lib/jvm/zulu-11 && \
+    \
+    # install supervisor
+    yum --enablerepo=extras install -y setuptools epel-release && \
+    yum install -y python-pip && \
+    pip install supervisor && \
+    \
+    # install commonly needed packages
+    yum install -y \
+        less `# helpful when troubleshooting product tests` \
+        net-tools `# netstat is required by run_on_docker.sh` \
+        sudo \
+        telnet `# helpful when troubleshooting product tests` \
+        vim `# helpful when troubleshooting product tests` \
+        && \
+    # cleanup
+    yum -y clean all && rm -rf /tmp/* /var/tmp/*
+
+COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
+
+ENV PATH="/usr/local/bin:${PATH}"
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
+ENV LANG=en_US.UTF-8

--- a/testing/centos7-oj8-arm64/files/opt/trinodev/site-override.xslt
+++ b/testing/centos7-oj8-arm64/files/opt/trinodev/site-override.xslt
@@ -1,0 +1,17 @@
+<!-- Copied from https://stackoverflow.com/a/31186191/65458 and adapted -->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes" />
+    <xsl:strip-space elements="*" />
+
+    <xsl:variable name="override-properties" select="document($override-path)/configuration/property" />
+
+    <xsl:template match="/configuration">
+        <xsl:copy>
+            <!-- copy local properties not overridden by external properties -->
+            <xsl:copy-of select="property[not(name=$override-properties/name)]" />
+            <!-- add all overriding properties -->
+            <xsl:copy-of select="$override-properties" />
+        </xsl:copy>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/testing/centos7-oj8-arm64/files/usr/local/bin/apply-all-site-xml-overrides
+++ b/testing/centos7-oj8-arm64/files/usr/local/bin/apply-all-site-xml-overrides
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+fail() {
+  echo "$(basename "$0"): $*" >&2
+  exit 1
+}
+
+if [ $# -ne 1 ]; then
+  fail "Usage: $0 <overrides dir>" >&2
+fi
+
+overrides_dir="$1"
+
+for file in $(find $overrides_dir -name '*.xml'); do
+    target_filename="${file#"$overrides_dir"}"
+    echo "Applying configuration override from $file to $target_filename"
+    apply-site-xml-override "$target_filename" "$file"
+done

--- a/testing/centos7-oj8-arm64/files/usr/local/bin/apply-site-xml-override
+++ b/testing/centos7-oj8-arm64/files/usr/local/bin/apply-site-xml-override
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+fail() {
+  echo "$(basename "$0"): $*" >&2
+  exit 1
+}
+
+if [ $# -ne 2 ]; then
+  fail "Usage: $0 <some-site.xml> <overrides.xml>" >&2
+fi
+
+site_xml="$1"
+overrides="$2"
+site_xml_new="$1.new"
+
+test -f "${site_xml}" || fail "${site_xml} does not exist or is not a file"
+test -f "${overrides}" || fail "${overrides} does not exist or is not a file"
+test ! -e "${site_xml_new}" || fail "${site_xml_new} already exists"
+
+xsltproc --param override-path "'${overrides}'" "/opt/trinodev/site-override.xslt" "${site_xml}" > "${site_xml_new}"
+cat "${site_xml_new}" > "${site_xml}" # Preserve file owner & permissions
+rm "${site_xml_new}"


### PR DESCRIPTION
This PR allows building Centos 7 images with JDK 11 and 8 that would run on ARM64, optionally with an emulator. It makes it possible to run selected Trino Product Tests on ARM64 and was used to manually test changes like https://github.com/trinodb/trino/pull/9148

This is a draft because there are a few open questions.

There are two options available:
1. Build a single `centos7-oj11` image for multiple architectures.
2. Build separate images

This PR implements option 2, because:
* It adds the `qemu-static` binary to the image, allowing to run it using an emulator. This binary can be mounted as a volume when creating the container, but it would then require changes in the Trino product test launcher.
* To make it simpler to run SEP on ARM64 but all other test dependencies on AMD64, because they might not have images for ARM64 available - it only requires changing the base image name instead of adding flags to the Docker client in `testcontainers`
* to avoid modifying the current build system in this repo

This causes an issue with the `bin/depend.sh` script, which does not support having multiple `FROM` entries in the `Dockerfile`. I'm not sure how to handle this. I could rewrite it to process all parent images in a loop.