### PR TITLE
Fix locale setting

### DIFF
--- a/testing/centos7-oj11/Dockerfile
+++ b/testing/centos7-oj11/Dockerfile
@@ -48,3 +48,4 @@ RUN \
 
 ENV PATH="/usr/local/bin:${PATH}"
 ENV JAVA_HOME=/usr/lib/jvm/zulu-11
+ENV LANG=en_US.UTF-8


### PR DESCRIPTION
`centos7-oj11`  image lacked `LANG` environment (as set in
`centos7-oj8`).  Locale defaulted to POSIX, which causes some tested
components to misbehave.