### PR TITLE
Disable buildkit when building docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ $(LATEST_TAGS): %@latest: %/Dockerfile %-parent-check
 	@echo
 	@echo "Building [$@] image"
 	@echo
-	cd $* && time $(SHELL) -c "( tar -czh . | docker build ${BUILD_ARGS} $(DBFLAGS_$*) -t $(call docker-tag,$@) --label $(LABEL) - )"
+	cd $* && time $(SHELL) -c "( tar -czh . | DOCKER_BUILDKIT=0 docker build ${BUILD_ARGS} $(DBFLAGS_$*) -t $(call docker-tag,$@) --label $(LABEL) - )"
 	docker history $(call docker-tag,$@)
 
 $(VERSION_TAGS): %@$(VERSION): %@latest


### PR DESCRIPTION
`ghcr.io/trinodb/testing/hdp2.6-hive:47` was built using buildkit
and it's broken due to the `/root` directory being owned by `uid:gid` `502:20`
which prevents socks proxy from starting correctly.

```
docker history ghcr.io/trinodb/testing/hdp2.6-hive:46 | head -n 2
IMAGE          CREATED        CREATED BY                                      SIZE      COMMENT
223486d20623   7 days ago     /bin/sh -c #(nop)  LABEL io.trino.git.hash=5…   0B
```

```
docker history ghcr.io/trinodb/testing/hdp2.6-hive:47 | head -n 2
IMAGE          CREATED        CREATED BY                                      SIZE      COMMENT
9ec25b2bd57f   2 days ago     CMD ["/bin/sh" "-c" "supervisord -c /etc/sup…   0B        buildkit.dockerfile.v0
```