### PR TITLE
Restore JDK 8 as default for hive3.1 and accumulo images

### DIFF
--- a/testing/accumulo/Dockerfile
+++ b/testing/accumulo/Dockerfile
@@ -15,6 +15,7 @@ FROM testing/centos7-oj11:unlabelled
 ARG ACCUMULO_VERSION=1.7.4
 ARG HADOOP_VERSION=2.6.5
 ARG ZOOKEEPER_VERSION=3.4.14
+ARG JAVA8_ZULU_VERSION=8.56.0.21-ca-jdk8.0.302
 ARG IMAGE_ROOT_INSTALL=/usr/local/lib
 
 ENV HADOOP_HOME=$IMAGE_ROOT_INSTALL/hadoop
@@ -32,6 +33,14 @@ ARG ZOOKEEPER_BINARY_PATH=$BASE_URL/zookeeper/zookeeper-$ZOOKEEPER_VERSION/zooke
 
 RUN yum update -y && \
     yum install -y gettext && \
+    # Install Zulu JDK
+    echo "Downloading zulu${JAVA8_ZULU_VERSION}-linux.x86_64.rpm..." && \
+    curl -o /tmp/jdk8.rpm --url https://cdn.azul.com/zulu/bin/zulu${JAVA8_ZULU_VERSION}-linux.x86_64.rpm && \
+    yum -y localinstall /tmp/jdk8.rpm && \
+    rm /tmp/jdk8.rpm && \
+    # Set JDK 8 as a default one
+    alternatives --set java /usr/lib/jvm/zulu-8/jre/bin/java && \
+    alternatives --set javac /usr/lib/jvm/zulu-8/bin/javac && \
     yum clean all -y
 
 RUN mkdir -p $IMAGE_ROOT_INSTALL

--- a/testing/hive3.1-hive/Dockerfile
+++ b/testing/hive3.1-hive/Dockerfile
@@ -12,13 +12,23 @@
 
 FROM testing/centos7-oj11:unlabelled
 
+ARG JAVA8_ZULU_VERSION=8.56.0.21-ca-jdk8.0.302
+
 RUN yum install -y \
     mariadb-server \
     openssh \
     openssh-clients \
     openssh-server \
     psmisc \
-    which \
+    which && \
+    # Install Zulu JDK
+    echo "Downloading zulu${JAVA8_ZULU_VERSION}-linux.x86_64.rpm..." && \
+    curl -o /tmp/jdk8.rpm --url https://cdn.azul.com/zulu/bin/zulu${JAVA8_ZULU_VERSION}-linux.x86_64.rpm && \
+    yum -y localinstall /tmp/jdk8.rpm && \
+    rm /tmp/jdk8.rpm && \
+    # Set JDK 8 as a default one
+    alternatives --set java /usr/lib/jvm/zulu-8/jre/bin/java && \
+    alternatives --set javac /usr/lib/jvm/zulu-8/bin/javac \
     && yum -q clean all && rm -rf /var/cache/yum
 
 ARG HADOOP_VERSION=3.1.2


### PR DESCRIPTION
https://github.com/trinodb/docker-images/pull/112 changed default JDK for those images from 8 to 11 which seems not to work. Restore JDK 8 as default JDK there.