### PR TITLE
Allow weak encryption algorithms in Kerberos

### DIFF
--- a/testing/cdh5.12-hive-kerberized/files/etc/krb5.conf
+++ b/testing/cdh5.12-hive-kerberized/files/etc/krb5.conf
@@ -8,6 +8,7 @@
  dns_lookup_realm = false
  dns_lookup_kdc = false
  forwardable = true
+ allow_weak_crypto = true
 
 [realms]
  LABS.TERADATA.COM = {

--- a/testing/cdh5.15-hive-kerberized/files/etc/krb5.conf
+++ b/testing/cdh5.15-hive-kerberized/files/etc/krb5.conf
@@ -8,6 +8,7 @@
  dns_lookup_realm = false
  dns_lookup_kdc = false
  forwardable = true
+ allow_weak_crypto = true
 
 [realms]
  LABS.TERADATA.COM = {

--- a/testing/hdp2.6-hive-kerberized-2/files/etc/krb5.conf
+++ b/testing/hdp2.6-hive-kerberized-2/files/etc/krb5.conf
@@ -8,6 +8,7 @@
  dns_lookup_realm = false
  dns_lookup_kdc = false
  forwardable = true
+ allow_weak_crypto = true
 
 [realms]
  OTHERREALM.COM = {

--- a/testing/hdp2.6-hive-kerberized/files/etc/krb5.conf
+++ b/testing/hdp2.6-hive-kerberized/files/etc/krb5.conf
@@ -8,6 +8,7 @@
  dns_lookup_realm = false
  dns_lookup_kdc = false
  forwardable = true
+ allow_weak_crypto = true
 
 [realms]
  LABS.TERADATA.COM = {

--- a/testing/hdp3.1-hive-kerberized/files/etc/krb5.conf
+++ b/testing/hdp3.1-hive-kerberized/files/etc/krb5.conf
@@ -8,6 +8,7 @@
  dns_lookup_realm = false
  dns_lookup_kdc = false
  forwardable = true
+ allow_weak_crypto = true
 
 [realms]
  LABS.TERADATA.COM = {

--- a/testing/kerberos/files/etc/krb5.conf
+++ b/testing/kerberos/files/etc/krb5.conf
@@ -8,6 +8,7 @@
  dns_lookup_realm = false
  dns_lookup_kdc = false
  forwardable = true
+ allow_weak_crypto = true
 
 [realms]
  STARBURSTDATA.COM = {


### PR DESCRIPTION
Some encryption types are now deprecated in JDK 17+ and will cause
Trino tests to fail. Enabling those types does not affect users in any
negative way as this applies only to testing infrastructure.

More details on introduced changes can be found under https://seanjmullan.org/blog/2021/09/14/jdk17