### PR TITLE
Use buildkit while building images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,9 +190,9 @@ $(UNLABELLED_TAGS): %@unlabelled: %/Dockerfile %@latest
 #
 $(LATEST_TAGS): %@latest: %/Dockerfile %-parent-check
 	@echo
-	@echo "Building [$@] image"
+	@echo "Building [$@] image using buildkit"
 	@echo
-	cd $* && time $(SHELL) -c "( tar -czh . | DOCKER_BUILDKIT=0 docker build ${BUILD_ARGS} $(DBFLAGS_$*) -t $(call docker-tag,$@) --label $(LABEL) - )"
+	cd $* && time $(SHELL) -c "( docker buildx build --compress --add-host hadoop-master:127.0.0.2 ${BUILD_ARGS} $(DBFLAGS_$*) -t $(call docker-tag,$@) --label $(LABEL) . )"
 	docker history $(call docker-tag,$@)
 
 $(VERSION_TAGS): %@$(VERSION): %@latest

--- a/testing/cdh5.12-hive/files/root/setup.sh
+++ b/testing/cdh5.12-hive/files/root/setup.sh
@@ -1,8 +1,5 @@
 #!/bin/bash -ex
 
-# make file system hostname resolvable
-echo "127.0.0.1 hadoop-master" >> /etc/hosts
-
 # format namenode
 chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/
 

--- a/testing/cdh5.15-hive-kerberized-kms/files/root/setup_kms.sh
+++ b/testing/cdh5.15-hive-kerberized-kms/files/root/setup_kms.sh
@@ -20,7 +20,6 @@ function retry() {
   return ${EXIT_CODE}
 }
 
-echo 127.0.0.2 `# must be different than localhost IP` hadoop-master >> /etc/hosts
 supervisord -c /etc/supervisord.conf &
 
 retry kinit -kt /etc/hadoop/conf/hdfs.keytab hdfs/hadoop-master@LABS.TERADATA.COM

--- a/testing/cdh5.15-hive/files/root/setup.sh
+++ b/testing/cdh5.15-hive/files/root/setup.sh
@@ -1,8 +1,5 @@
 #!/bin/bash -ex
 
-# make file system hostname resolvable
-echo "127.0.0.1 hadoop-master" >> /etc/hosts
-
 # format namenode
 chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/
 

--- a/testing/hdp2.6-hive/files/root/setup.sh
+++ b/testing/hdp2.6-hive/files/root/setup.sh
@@ -1,8 +1,5 @@
 #!/bin/bash -ex
 
-# make file system hostname resolvable
-echo "127.0.0.1 hadoop-master" >> /etc/hosts
-
 # format namenode
 chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/
 

--- a/testing/hdp3.1-hive/files/root/setup.sh
+++ b/testing/hdp3.1-hive/files/root/setup.sh
@@ -1,8 +1,5 @@
 #!/bin/bash -ex
 
-# make file system hostname resolvable
-echo "127.0.0.1 hadoop-master" >> /etc/hosts
-
 # format namenode
 chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/
 


### PR DESCRIPTION
Buildkit is faster and does caching better when building images.
In the near future, it will become a default docker build tooling.