### PR TITLE
Support multiarch images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ jobs:
           - image: accumulo
           - image: dns
           - image: centos7-oj11
+            platforms: linux/amd64,linux/arm64
           - image: centos7-oj11-openldap-referrals
+            platforms: linux/amd64,linux/arm64
           - image: spark3.0-iceberg
           - image: spark3-delta
           - image: kerberos
@@ -36,8 +38,12 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0 # checkout tags so version in Manifest is set properly
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
     - name: Build ${{ matrix.config.image }}
-      run: make "testing/${{ matrix.config.image }}"
+      run: make "testing/${{ matrix.config.image }}" PLATFORMS=${{ matrix.config.platforms }}
     - name: Test ${{ matrix.config.test }}
       if: ${{ matrix.config.test  != '' }}
       shell: 'script -q -e -c "bash {0}"'

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@ FLAGS := $(foreach dockerfile,$(DOCKERFILES),$(FLAGDIR)/$(dockerfile:/Dockerfile
 RELEASE_TAGS := $(VERSION_TAGS) $(LATEST_TAGS)
 SNAPSHOT_TAGS := $(GIT_HASH_TAGS)
 
+TARGET_PLATFORMS := $(if $(PLATFORMS),--platform $(PLATFORMS),)
+
 #
 # Make a list of the Docker images we depend on, but aren't built from
 # Dockerfiles in this repository. Order doesn't matter, but sort() has the
@@ -192,7 +194,7 @@ $(LATEST_TAGS): %@latest: %/Dockerfile %-parent-check
 	@echo
 	@echo "Building [$@] image using buildkit"
 	@echo
-	cd $* && time $(SHELL) -c "( docker buildx build --compress --add-host hadoop-master:127.0.0.2 ${BUILD_ARGS} $(DBFLAGS_$*) -t $(call docker-tag,$@) --label $(LABEL) . )"
+	cd $* && time $(SHELL) -c "( docker buildx build ${TARGET_PLATFORMS} --compress --add-host hadoop-master:127.0.0.2 ${BUILD_ARGS} $(DBFLAGS_$*) -t $(call docker-tag,$@) --label $(LABEL) --load . )"
 	docker history $(call docker-tag,$@)
 
 $(VERSION_TAGS): %@$(VERSION): %@latest

--- a/testing/centos7-oj11/Dockerfile
+++ b/testing/centos7-oj11/Dockerfile
@@ -14,6 +14,8 @@ FROM library/centos:7
 
 COPY ./files /
 
+ARG TARGETPLATFORM
+
 # Install Java and presto-admin dependences
 RUN \
     set -xeu && \
@@ -23,9 +25,11 @@ RUN \
         && \
     \
     # install Zulu JDK
-    rpm -i https://cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-linux.x86_64.rpm && \
+    if [ "$TARGETPLATFORM" = "linux/arm64" ]; then JDK11="https://cdn.azul.com/zulu-embedded/bin/zulu11.58.15-ca-jdk11.0.16-linux.aarch64.rpm"; else JDK11="https://cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-linux.x86_64.rpm"; fi && \
+    rpm -i $JDK11 && \
     # Install additional Zulu JDK 17.0.3
-    rpm -i https://cdn.azul.com/zulu/bin/zulu17.34.19-ca-jdk17.0.3-linux.x86_64.rpm && \
+    if [ "$TARGETPLATFORM" = "linux/arm64" ]; then JDK17="https://cdn.azul.com/zulu/bin/zulu17.36.13-ca-jdk17.0.4-linux.aarch64.rpm"; else JDK17="https://cdn.azul.com/zulu/bin/zulu17.34.19-ca-jdk17.0.3-linux.x86_64.rpm"; fi && \
+    rpm -i $JDK17 && \
     # Set JDK 11 as a default one
     alternatives --set java /usr/lib/jvm/zulu-11/bin/java && \
     alternatives --set javac /usr/lib/jvm/zulu-11/bin/javac && \


### PR DESCRIPTION
The goal is to be able to create multi arch images for selected images in order for Trino tests to perform better and more reliable on ARM machines (M1 laptops).

The initial candidate is the centos7-oj11 image that is used for running the presto-master in the Trino product tests.