### PR TITLE
Make sure VERSION is defined before trying to commit/tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           git log
           DO_RELEASE=true
         fi
-        VERSION=$(sed -n 's/^\([0-9]\+\).*$/\1/p' version | head -n 1)
+        VERSION=$(cat version)
         echo "VERSION=${VERSION}" >> $GITHUB_ENV
         echo "DO_RELEASE=${DO_RELEASE}" >> $GITHUB_ENV
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
         DO_RELEASE=false
         if grep -q '^[0-9]\+-SNAPSHOT$' version; then
           sed -i 's/^\([0-9]\+\)-SNAPSHOT$/\1/' version
+          VERSION=$(cat version)
           git diff
           git commit -a -m "Release: $VERSION"
           git tag -m "" "$VERSION"


### PR DESCRIPTION
Fixes release flow. See failure in https://github.com/trinodb/docker-images/runs/7802451805?check_suite_focus=true