### PR TITLE
Replace git log with more targeted commands in release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,8 @@ jobs:
           git diff
           git commit -a -m "Release: $VERSION"
           git tag -m "" "$VERSION"
-          git log
+          # Verify tag was created and points to the release commit
+          git show tags/"$VERSION"
           DO_RELEASE=true
         fi
         VERSION=$(cat version)
@@ -58,5 +59,6 @@ jobs:
         echo "$VERSION-SNAPSHOT" > version
         git diff
         git commit -a -m "Prepare for next development iteration"
-        git log
+        # Show the contents of the commit
+        git show HEAD
         git push --tags origin master


### PR DESCRIPTION
git log was being used to verify whether the tag exists and points to
correct commit and to see whether the version bump commit was correct.

Both usages are now replaced with more appropriate commands to reduce
noise from large git log output in CI logs.