### PR TITLE
Fix releases with multiarch images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,11 +93,15 @@ jobs:
           exit 2
         fi
         make prepare-release
+
         make "${single_arch[@]/%/@$VERSION}"
-        make "${multi_arch[@]/%/@$VERSION}" PLATFORM="linux/amd64,linux/arm64"
-        remote=("${to_release[@]/#/ghcr.io/trinodb/}")
-        remote=("${remote[@]/%/:$VERSION}")
-        ./bin/push.sh "${remote[@]}"
+        make "${multi_arch[@]/%/@$VERSION}" PLATFORMS="linux/amd64,linux/arm64"
+
+        single_remote=("${single_arch[@]/#/ghcr.io/trinodb/}")
+        ./bin/push.sh "${single_remote[@]/%/:$VERSION}"
+        export PLATFORMS="linux/amd64,linux/arm64"
+        multi_remote=("${multi_arch[@]/#/ghcr.io/trinodb/}")
+        ./bin/push.sh "${multi_remote[@]/%/:$VERSION}"
 
     - name: Set next development version
       run: |

--- a/bin/push.sh
+++ b/bin/push.sh
@@ -11,7 +11,7 @@ function push_retry() {
     done
 }
 
-if [ -z "$PLATFORMS" ]; then
+if [ -z "${PLATFORMS:-}" ]; then
     for image in "$@"; do
         push_retry "$image"
     done


### PR DESCRIPTION
I spotted and fixed two issues:
* `bin/push.sh` didn't correctly check if `PLATFORMS` is set
* the release workflow didn't call `make` and `bin/push.sh` with correct value of `PLATFORMS`