### PR TITLE
Install libxslt on hive3 docker container

### DIFF
--- a/testing/hive3.1-hive/Dockerfile
+++ b/testing/hive3.1-hive/Dockerfile
@@ -20,6 +20,7 @@ RUN yum install -y \
     openssh \
     openssh-clients \
     openssh-server \
+    libxslt \
     psmisc \
     which && \
     # Install Zulu JDK


### PR DESCRIPTION
This xml parsing tool is being used at apply-site-xml-override script. 

Install the tool would allow hive3 container to use apply-site-xml-override tool and override configs such as  core-site.xml and hdfs-site.xml