### PR TITLE
Add command to connect to the metastore database in the `~/.bash_history`

### DIFF
--- a/testing/hdp2.6-hive/Dockerfile
+++ b/testing/hdp2.6-hive/Dockerfile
@@ -28,6 +28,13 @@ RUN \
     alternatives --set javac /usr/lib/jvm/zulu-17/bin/javac && \
     echo "Done"
 
+# Provide convenience bash history
+RUN set -xeu; \
+    for user in root hive hdfs; do \
+        # ~hive might be owned by root
+        chown -R "${user}:" "$(eval echo ~"${user}")"; \
+        sudo -u "${user}" bash -c ' echo "mysql -u root -proot -D metastore" >> ~/.bash_history '; \
+    done
 # HDFS ports
 EXPOSE 1004 1006 8020 50010 50020 50070 50075 50470
 

--- a/testing/hdp3.1-hive/Dockerfile
+++ b/testing/hdp3.1-hive/Dockerfile
@@ -28,6 +28,13 @@ RUN \
     alternatives --set javac /usr/lib/jvm/zulu-17/bin/javac && \
     echo "Done"
 
+# Provide convenience bash history
+RUN set -xeu; \
+    for user in root hive hdfs; do \
+        # ~hive might be owned by root
+        chown -R "${user}:" "$(eval echo ~"${user}")"; \
+        sudo -u "${user}" bash -c ' echo "mysql -u root -proot -D metastore" >> ~/.bash_history '; \
+    done
 # HDFS ports
 EXPOSE 1004 1006 8020 9866 9867 9870 9864 50470
 


### PR DESCRIPTION
It is more uncommon, but sometimes we want to connect to the MySQL database backing the metastore from the Hadoop images.

Added the command used to connect to this database in the `~/.bash_history` in order to have it available in case we want to make use of it.