### PR TITLE
Relax Hive-3 column datatype changes

### DIFF
--- a/testing/hdp3.1-hive/files/etc/hive/conf/hive-site.xml
+++ b/testing/hdp3.1-hive/files/etc/hive/conf/hive-site.xml
@@ -90,4 +90,9 @@
         <value>org.apache.hadoop.hive.ql.lockmgr.DbTxnManager</value>
     </property>
 
+    <property>
+        <name>hive.metastore.disallow.incompatible.col.type.changes</name>
+        <value>false</value>
+    </property>
+
 </configuration>

--- a/testing/hive3.1-hive/files/opt/hive/conf/hive-site.xml
+++ b/testing/hive3.1-hive/files/opt/hive/conf/hive-site.xml
@@ -78,4 +78,9 @@
         <value>"Use AWS_SECRET_ACCESS_KEY environment variable to set this value"</value>
     </property>
 
+    <property>
+        <name>hive.metastore.disallow.incompatible.col.type.changes</name>
+        <value>false</value>
+    </property>
+
 </configuration>


### PR DESCRIPTION
This would make Hive 2 and Hive 3 to have similar restriction for column type changes.
In case of hive2 - the default value of an equivalent property  hive.metastore.disallow.incompatible.col.type.changes is false.
Preparatory PR for https://github.com/trinodb/trino/pull/15898