### PR TITLE
Update download url for hive binary

### DIFF
--- a/testing/hive3.1-hive/Dockerfile
+++ b/testing/hive3.1-hive/Dockerfile
@@ -40,7 +40,7 @@ ARG HIVE_VERSION=3.1.2
 
 # TODO Apache Archive is rate limited -- these should probably go in S3
 ARG HADOOP_BINARY_PATH=https://archive.apache.org/dist/hadoop/common/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz
-ARG HIVE_BINARY_PATH=https://apache.mivzakim.net/hive/hive-$HIVE_VERSION/apache-hive-$HIVE_VERSION-bin.tar.gz
+ARG HIVE_BINARY_PATH=https://downloads.apache.org/hive/hive-$HIVE_VERSION/apache-hive-$HIVE_VERSION-bin.tar.gz
 
 RUN curl -fLsS -o /tmp/hadoop.tar.gz --url $HADOOP_BINARY_PATH && \
     tar xzf /tmp/hadoop.tar.gz --directory /opt && mv /opt/hadoop-$HADOOP_VERSION /opt/hadoop


### PR DESCRIPTION
Previous URL was taking too long to download hive binary. 

Now the build time for hive-3.1 was reduced from 2h+ to around 20-30mins. 