### PR TITLE
Add missing image to single arch images list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,7 @@ jobs:
           testing/hdp2.6-hive-kerberized-2
           testing/hdp3.1-hive
           testing/hdp3.1-hive-kerberized
+          testing/hdp3.1-hive-kerberized-2
         )
         multi_arch=(
           testing/centos7-oj11


### PR DESCRIPTION
[Latest release](https://github.com/trinodb/docker-images/actions/runs/6089349336) failed because of the new image added in #172. Add it to the single arch images list.