### PR TITLE
Free up some disk space during releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,10 @@ jobs:
 
         single_remote=("${single_arch[@]/#/ghcr.io/trinodb/}")
         ./bin/push.sh "${single_remote[@]/%/:$VERSION}"
+
+        # free up disk space
+        docker system prune --all --force --volumes
+
         export PLATFORMS="linux/amd64,linux/arm64"
         multi_remote=("${multi_arch[@]/#/ghcr.io/trinodb/}")
         ./bin/push.sh "${multi_remote[@]/%/:$VERSION}"


### PR DESCRIPTION
After adding a new single arch image, the release failed after running out of disk space on the workflow runner node. Clean up some space after building single arch images.