### PR TITLE
Prune only dangling images during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,14 +102,12 @@ jobs:
         make prepare-release
 
         make "${single_arch[@]/%/@$VERSION}"
+        # free up disk space
+        docker system prune --volumes
         make "${multi_arch[@]/%/@$VERSION}" PLATFORMS="linux/amd64,linux/arm64"
 
         single_remote=("${single_arch[@]/#/ghcr.io/trinodb/}")
         ./bin/push.sh "${single_remote[@]/%/:$VERSION}"
-
-        # free up disk space
-        docker system prune --all --force --volumes
-
         export PLATFORMS="linux/amd64,linux/arm64"
         multi_remote=("${multi_arch[@]/#/ghcr.io/trinodb/}")
         ./bin/push.sh "${multi_remote[@]/%/:$VERSION}"


### PR DESCRIPTION
The previous attempt in #174 to free up disk space during release was wrong, as it did pruning between pushing images, not between building them for single vs multi arch. Do it earlier, but only remove dangling (untagged) images. This also removes dangling build cache.