### PR TITLE
Free up some disk space on the runner before doing a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,20 @@ jobs:
       contents: write
       packages: write
     steps:
+    - name: Free up disk space
+      run: |
+        sudo rm -rf \
+          /usr/share/dotnet \
+          /opt/ghc \
+          /usr/local/share/boost \
+          "$AGENT_TOOLSDIRECTORY" || true
+        docker rmi $(docker image ls -aq) >/dev/null 2>&1 || true
+    - name: Report disk space usage
+      run: |
+        sudo dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -nr | head
+        df -h .
+        sudo du -hx -d 4 --threshold=1G /usr/ | sort -hr | head
+
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0 # checkout tags so version in Manifest is set properly


### PR DESCRIPTION
Another attempt (after #174) to make more space for building all images during the release. This should free up more than 10GB. 

Reference: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930