### PR TITLE
Update base centos7 images

### DIFF
--- a/testing/centos7-oj11/Dockerfile
+++ b/testing/centos7-oj11/Dockerfile
@@ -17,6 +17,7 @@ COPY ./files /
 # Install Java and presto-admin dependences
 RUN \
     set -xeu && \
+    yum update -y && \
     yum install -y \
         nc \
         wget \

--- a/testing/centos7-oj17/Dockerfile
+++ b/testing/centos7-oj17/Dockerfile
@@ -17,6 +17,7 @@ COPY ./files /
 # Install Java and presto-admin dependences
 RUN \
     set -xeu && \
+    yum update -y && \
     yum install -y \
         nc \
         wget \


### PR DESCRIPTION
This updates ca-certificates that allow us to connect to archive.apache.org securely.