### PR TITLE
Set timeout for build-images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   build-images:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The job failed after 6 hours in https://github.com/trinodb/docker-images/actions/runs/8259379627/job/22593193755?pr=190. It would be nice to set timeout. 

I chose 60 minutes because `ci / build-images (hive3.1-hive, linux/amd64,linux/arm64, hive3.1-hive) (push)` took 40 minutes in https://github.com/trinodb/docker-images/actions/runs/7921889852/job/21628209184

