### PR TITLE
Fix ssl certificate error and broken Hive download link

### DIFF
--- a/testing/centos7-oj11/Dockerfile
+++ b/testing/centos7-oj11/Dockerfile
@@ -31,8 +31,7 @@ RUN \
     \
     # install supervisor
     yum --enablerepo=extras install -y setuptools epel-release && \
-    yum install -y python-pip && \
-    pip install supervisor && \
+    yum install -y supervisor && \
     \
     # install commonly needed packages
     yum install -y \

--- a/testing/centos7-oj17/Dockerfile
+++ b/testing/centos7-oj17/Dockerfile
@@ -31,8 +31,7 @@ RUN \
     \
     # install supervisor
     yum --enablerepo=extras install -y setuptools epel-release && \
-    yum install -y python-pip && \
-    pip install supervisor && \
+    yum install -y supervisor && \
     \
     # install commonly needed packages
     yum install -y \

--- a/testing/hive3.1-hive/Dockerfile
+++ b/testing/hive3.1-hive/Dockerfile
@@ -36,11 +36,11 @@ RUN yum install -y \
 ENV JAVA_HOME=/usr/lib/jvm/zulu-8
 
 ARG HADOOP_VERSION=3.1.2
-ARG HIVE_VERSION=3.1.2
+ARG HIVE_VERSION=3.1.3
 
 # TODO Apache Archive is rate limited -- these should probably go in S3
 ARG HADOOP_BINARY_PATH=https://archive.apache.org/dist/hadoop/common/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz
-ARG HIVE_BINARY_PATH=https://downloads.apache.org/hive/hive-$HIVE_VERSION/apache-hive-$HIVE_VERSION-bin.tar.gz
+ARG HIVE_BINARY_PATH=https://dlcdn.apache.org/hive/hive-$HIVE_VERSION/apache-hive-$HIVE_VERSION-bin.tar.gz
 
 RUN curl -fLsS -o /tmp/hadoop.tar.gz --url $HADOOP_BINARY_PATH && \
     tar xzf /tmp/hadoop.tar.gz --directory /opt && mv /opt/hadoop-$HADOOP_VERSION /opt/hadoop


### PR DESCRIPTION
```
Could not fetch URL https://pypi.python.org/simple/supervisor/: There was a problem confirming the ssl certificate: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:618) - skipping
Could not find a version that satisfies the requirement supervisor (from versions: )
```