### PR TITLE
Add Unity catalog docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
           # TODO add test https://github.com/trinodb/trino/issues/14543
           - image: phoenix5
             platforms: linux/amd64,linux/arm64
+          - image: unity-catalog
+            test: unity-catalog
     steps:
     - uses: actions/checkout@v3
       with:

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -183,6 +183,9 @@ for ARCH in "${platforms[@]}"; do
     elif [[ ${ENVIRONMENT} == *"polaris"* ]]; then
         # TODO Add test for Polaris
         test true
+    elif [[ ${ENVIRONMENT} == *"unity"* ]]; then
+        # TODO Add test for Unity
+        test true
     elif [[ ${ENVIRONMENT} == "kerberos" ]]; then
         run_kerberos_tests
     elif [[ ${ENVIRONMENT} == *"hive"* ]]; then

--- a/etc/compose/unity-catalog/docker-compose.yml
+++ b/etc/compose/unity-catalog/docker-compose.yml
@@ -1,0 +1,4 @@
+version: '2.0'
+services:
+  polaris:
+    image: testing/unity-catalog:latest

--- a/testing/unity-catalog/Dockerfile
+++ b/testing/unity-catalog/Dockerfile
@@ -1,0 +1,28 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG ARCH
+FROM testing/almalinux9-oj17:unlabelled$ARCH
+
+RUN yum update -y && \
+    yum install -y git && \
+    yum clean all -y
+
+RUN git clone https://github.com/unitycatalog/unitycatalog.git unity
+
+WORKDIR unity
+
+RUN build/sbt package
+
+EXPOSE 8080
+
+CMD ["bin/start-uc-server"]


### PR DESCRIPTION
Add temporary docker image until Unity catalog publish their image: https://github.com/unitycatalog/unitycatalog

Manual confirmation:
```sh
➜  docker-images git:(ebi/unity-catalog) docker run -p 8080:8080 testing/unity-catalog
###################################################################
#  _    _       _ _            _____      _        _              #
# | |  | |     (_) |          / ____|    | |      | |             #
# | |  | |_ __  _| |_ _   _  | |     __ _| |_ __ _| | ___   __ _  #
# | |  | | '_ \| | __| | | | | |    / _` | __/ _` | |/ _ \ / _` | #
# | |__| | | | | | |_| |_| | | |___| (_| | || (_| | | (_) | (_| | #
#  \____/|_| |_|_|\__|\__, |  \_____\__,_|\__\__,_|_|\___/ \__, | #
#                      __/ |                                __/ | #
#                     |___/               v0.2.0-SNAPSHOT  |___/  #
###################################################################


➜  docker-images git:(ebi/unity-catalog) curl http://localhost:8080
Hello, Unity Catalog!%
```
