### PR TITLE
Move polaris-catalog to multi_arch + Add unity-catalog to release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,6 @@ jobs:
           testing/hdp3.1-hive-kerberized
           testing/hdp3.1-hive-kerberized-2
           testing/hdp3.1-hive-kerberized-kms
-          testing/polaris-catalog
         )
         multi_arch=(
           testing/almalinux9-oj11
@@ -91,6 +90,7 @@ jobs:
           testing/spark3-delta
           testing/spark3-iceberg
           testing/spark3-hudi
+          testing/polaris-catalog
         )
         referenced_images=("${skipped_images[@]}" "${single_arch[@]}" "${multi_arch[@]}")
         make meta

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,7 @@ jobs:
           testing/spark3-iceberg
           testing/spark3-hudi
           testing/polaris-catalog
+          testing/unity-catalog
         )
         referenced_images=("${skipped_images[@]}" "${single_arch[@]}" "${multi_arch[@]}")
         make meta


### PR DESCRIPTION
Fix failing release job: https://github.com/trinodb/docker-images/actions/runs/11271512937
```
Images that would not get released: testing/unity-catalog
Must be explicitly added to either single_arch or multi_arch list or should be added to skipped list
```