### PR TITLE
Use archive.apache.org domain for Apache Hive

### DIFF
--- a/testing/hive3.1-hive/Dockerfile
+++ b/testing/hive3.1-hive/Dockerfile
@@ -41,7 +41,7 @@ ARG HIVE_VERSION=3.1.3
 
 # TODO Apache Archive is rate limited -- these should probably go in S3
 ARG HADOOP_BINARY_PATH=https://archive.apache.org/dist/hadoop/common/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz
-ARG HIVE_BINARY_PATH=https://dlcdn.apache.org/hive/hive-$HIVE_VERSION/apache-hive-$HIVE_VERSION-bin.tar.gz
+ARG HIVE_BINARY_PATH=https://archive.apache.org/dist/hive/hive-$HIVE_VERSION/apache-hive-$HIVE_VERSION-bin.tar.gz
 
 RUN curl -fLsS -o /tmp/hadoop.tar.gz --url $HADOOP_BINARY_PATH && \
     tar xzf /tmp/hadoop.tar.gz --directory /opt && mv /opt/hadoop-$HADOOP_VERSION /opt/hadoop


### PR DESCRIPTION
The job is failing on master because 3.1.3 no longer exists in https://dlcdn.apache.org/hive. 
```
#8 ERROR: process "/bin/sh -c curl -fLsS -o /tmp/hive.tar.gz --url $HIVE_BINARY_PATH &&     tar xzf /tmp/hive.tar.gz --directory /opt && mv /opt/apache-hive-${HIVE_VERSION}-bin /opt/hive" did not complete successfully: exit code: 22
------
 > [ 4/10] RUN curl -fLsS -o /tmp/hive.tar.gz --url https://dlcdn.apache.org/hive/hive-3.1.3/apache-hive-3.1.3-bin.tar.gz &&     tar xzf /tmp/hive.tar.gz --directory /opt && mv /opt/apache-hive-3.1.3-bin /opt/hive:
0.583 curl: (22) The requested URL returned error: 404
------
```
https://github.com/trinodb/docker-images/actions/runs/11271958170/job/31345890289