### PR TITLE
Revert reducing image size of Unity catalog

### DIFF
--- a/testing/unity-catalog/Dockerfile
+++ b/testing/unity-catalog/Dockerfile
@@ -11,22 +11,17 @@
 # limitations under the License.
 
 ARG ARCH
-FROM testing/almalinux9-oj17:unlabelled$ARCH AS builder
+FROM testing/almalinux9-oj17:unlabelled$ARCH
 
 RUN yum update -y && \
     yum install -y git && \
     yum clean all -y
 
-RUN git clone --depth=1 https://github.com/unitycatalog/unitycatalog.git unity
+RUN git clone https://github.com/unitycatalog/unitycatalog.git unity
 
-WORKDIR /unity
+WORKDIR unity
 
 RUN build/sbt package
-
-FROM testing/almalinux9-oj17:unlabelled$ARCH
-
-WORKDIR /unity
-COPY --from=builder /unity /unity
 
 EXPOSE 8080
 


### PR DESCRIPTION
Trino CI started failing after https://github.com/trinodb/docker-images/pull/214. Polaris change looks fine. 

I tried other approaches, but couldn't reduce the size without breaking the image. 