### PR TITLE
Fix Polaris image

### DIFF
--- a/testing/polaris-catalog/Dockerfile
+++ b/testing/polaris-catalog/Dockerfile
@@ -12,7 +12,7 @@
 
 FROM gradle:8.11-jdk21 AS builder
 
-RUN git clone --depth=1 https://github.com/polaris-catalog/polaris.git /polaris
+RUN git clone --depth=1 https://github.com/apache/polaris.git /polaris
 
 WORKDIR /polaris
 

--- a/testing/polaris-catalog/Dockerfile
+++ b/testing/polaris-catalog/Dockerfile
@@ -20,7 +20,7 @@ RUN gradle --no-daemon --info shadowJar
 
 FROM eclipse-temurin:21-jre-alpine
 
-COPY --from=builder /polaris/polaris-service/build/libs/polaris-service-1.0.0-incubating-SNAPSHOT.jar /polaris-service.jar
+COPY --from=builder /polaris/dropwizard/service/build/libs/polaris-dropwizard-service-1.0.0-incubating-SNAPSHOT.jar /polaris-service.jar
 COPY --from=builder /polaris/polaris-server.yml /polaris-server.yml
 
 EXPOSE 8181


### PR DESCRIPTION
With the the recent module breakdown(https://github.com/apache/polaris/pull/523) in Polaris repo, update Polaris Dockerfile with renamed Polaris executable jar location. 