### PR TITLE
Add iceberg-aws-bundle to Iceberg image

### DIFF
--- a/testing/spark3-iceberg/Dockerfile
+++ b/testing/spark3-iceberg/Dockerfile
@@ -44,6 +44,7 @@ RUN wget -nv https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2
 
 # install Iceberg
 RUN wget -nv "https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-${ICEBERG_JAR_VERSION}/${ICEBERG_VERSION}/iceberg-spark-runtime-${ICEBERG_JAR_VERSION}-${ICEBERG_VERSION}.jar"
+RUN wget -nv "https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-aws-bundle/${ICEBERG_VERSION}/iceberg-aws-bundle-${ICEBERG_VERSION}.jar"
 
 # install PostgreSQL driver for JDBC catalog
 RUN wget -nv "https://repo1.maven.org/maven2/org/postgresql/postgresql/${POSTGRESQL_JAR_VERSION}/postgresql-${POSTGRESQL_JAR_VERSION}.jar"


### PR DESCRIPTION
The module is required to run Iceberg product tests with MinIO. 