### PR TITLE
Restore testing/hive4.0-hive in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,7 @@ jobs:
           testing/spark3-delta
           testing/spark3-iceberg
           testing/spark3-hudi
+          testing/hive4.0-hive
         )
         referenced_images=("${skipped_images[@]}" "${single_arch[@]}" "${multi_arch[@]}")
         make meta


### PR DESCRIPTION
I accidentally removed the line in https://github.com/trinodb/docker-images/pull/223/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L94