### PR TITLE
Pin QEMU version temporarily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
         fetch-depth: 0 # checkout tags so version in Manifest is set properly
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
+      with:
+        ## Temporary due to bug in qemu:  https://github.com/docker/setup-qemu-action/issues/198
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
     - name: Build ${{ matrix.image }}
       env:
         PLATFORMS: ${{ matrix.platforms }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
+      with:
+        ## Temporary due to bug in qemu:  https://github.com/docker/setup-qemu-action/issues/198
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Log in to the Container registry
       # locked to https://github.com/docker/login-action/releases/tag/v2.1.0


### PR DESCRIPTION
Release job is still failing: https://github.com/trinodb/docker-images/actions/runs/13324968118/job/37216185043

Relates to https://github.com/docker/setup-qemu-action/issues/198