### PR TITLE
Reenable Polaris and Unity catalogs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,8 @@ jobs:
           - image: almalinux9-oj17-openldap-active-directory
             platforms: linux/amd64,linux/arm64
             test: openldap-active-directory
-          # TODO https://github.com/trinodb/trino/issues/24945 Reenable Polaris tests in Iceberg
-          # - image: polaris-catalog
-          #  test: polaris-catalog
+          - image: polaris-catalog
+            test: polaris-catalog
           - image: spark3-iceberg
             platforms: linux/amd64,linux/arm64
             test: spark3-iceberg
@@ -45,9 +44,8 @@ jobs:
           # TODO add test https://github.com/trinodb/trino/issues/14543
           - image: phoenix5
             platforms: linux/amd64,linux/arm64
-          # TODO https://github.com/trinodb/trino/issues/24945 Reenable Unity tests in Iceberg
-          # - image: unity-catalog
-          #   test: unity-catalog
+          - image: unity-catalog
+            test: unity-catalog
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,6 @@ jobs:
         fi
         skipped_images=(
           testing/almalinux9-oj17-openldap-base
-          testing/polaris-catalog
-          testing/unity-catalog
         )
         single_arch=(
           testing/hdp3.1-hive
@@ -95,6 +93,8 @@ jobs:
           testing/spark3-iceberg
           testing/spark3-hudi
           testing/hive4.0-hive
+          testing/polaris-catalog
+          testing/unity-catalog
         )
         referenced_images=("${skipped_images[@]}" "${single_arch[@]}" "${multi_arch[@]}")
         make meta

--- a/testing/polaris-catalog/Dockerfile
+++ b/testing/polaris-catalog/Dockerfile
@@ -16,13 +16,15 @@ RUN git clone --depth=1 https://github.com/apache/polaris.git /polaris
 
 WORKDIR /polaris
 
-RUN gradle --no-daemon --info shadowJar
+RUN gradle :polaris-quarkus-server:build
 
 FROM eclipse-temurin:21-jre-alpine
 
-COPY --from=builder /polaris/dropwizard/service/build/libs/polaris-dropwizard-service-1.0.0-incubating-SNAPSHOT.jar /polaris-service.jar
-COPY --from=builder /polaris/polaris-server.yml /polaris-server.yml
+ARG POLARIS_VERSION=1.0.0-incubating-SNAPSHOT
+
+COPY --from=builder /polaris/quarkus/server/build/distributions/polaris-quarkus-server-1.0.0-incubating-SNAPSHOT.zip /polaris-quarkus-server-${POLARIS_VERSION}.zip
+RUN unzip polaris-quarkus-server-${POLARIS_VERSION}.zip
 
 EXPOSE 8181
 
-CMD ["java", "-jar", "polaris-service.jar", "server", "polaris-server.yml"]
+CMD ["java", "-jar", "polaris-quarkus-server-${POLARIS_VERSION}/quarkus-run.jar"]


### PR DESCRIPTION
Fix [Polaris build failure](https://github.com/trinodb/docker-images/actions/runs/13623035426/job/38075621405?pr=228) and reenable Polaris and Unity catalogs.