### PR TITLE
Remove obsolete version attribute

### DIFF
--- a/etc/compose/hdp3.1-hive/docker-compose.yml
+++ b/etc/compose/hdp3.1-hive/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.0'
 services:
   hadoop-master:
     hostname: hadoop-master

--- a/etc/compose/hive3.1-hive/docker-compose.yml
+++ b/etc/compose/hive3.1-hive/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.0'
 services:
   hadoop-master:
     hostname: hadoop-master

--- a/etc/compose/hive4.0-hive/docker-compose.yml
+++ b/etc/compose/hive4.0-hive/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.0'
 services:
   hiveserver2:
     hostname: hiveserver2

--- a/etc/compose/kerberos/docker-compose.yml
+++ b/etc/compose/kerberos/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.0'
 services:
   kerberos:
     image: testing/kerberos:latest$ARCH

--- a/etc/compose/openldap-active-directory/docker-compose.yml
+++ b/etc/compose/openldap-active-directory/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.0'
 services:
   openldap:
     image: testing/almalinux9-oj17-openldap-active-directory:latest$ARCH

--- a/etc/compose/openldap/docker-compose.yml
+++ b/etc/compose/openldap/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.0'
 services:
   openldap:
     image: testing/almalinux9-oj17-openldap:latest$ARCH

--- a/etc/compose/polaris-catalog/docker-compose.yml
+++ b/etc/compose/polaris-catalog/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.0'
 services:
   polaris:
     image: testing/polaris-catalog:latest

--- a/etc/compose/spark3-hudi/docker-compose.yml
+++ b/etc/compose/spark3-hudi/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.0'
 services:
   spark:
     image: testing/spark3-hudi:latest$ARCH

--- a/etc/compose/spark3-iceberg/docker-compose.yml
+++ b/etc/compose/spark3-iceberg/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.0'
 services:
   spark:
     image: testing/spark3-iceberg:latest$ARCH

--- a/etc/compose/spark4-delta/docker-compose.yml
+++ b/etc/compose/spark4-delta/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.0'
 services:
   spark:
     image: testing/spark4-delta:latest$ARCH

--- a/etc/compose/unity-catalog/docker-compose.yml
+++ b/etc/compose/unity-catalog/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.0'
 services:
   polaris:
     image: testing/unity-catalog:latest


### PR DESCRIPTION
Fix the following warning:
```
WARN[0000] /home/runner/work/docker-images/docker-images/etc/compose/openldap/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
```