### PR TITLE
ci: declare `contents: read` on the docker-images build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: ci
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build-images:
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
The `ci` workflow builds and tests Docker images. It does not push to a registry or call the GitHub API beyond checkout, so workflow-level `contents: read` is the right cap for the default `GITHUB_TOKEN`.

Same post-CVE-2025-30066 hardening pattern that became standard after the `tj-actions/changed-files` compromise. YAML validated locally.